### PR TITLE
Add the possibility to set return type.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,9 @@ const builder = <a, b>(
       },
     ]).run(),
 
+  as: <c>(): Match<a, PickReturnValue<b, c>>  =>
+    builder<a, PickReturnValue<b, c>>(value, patterns),
+
   run: (): b => {
     const entry = patterns.find(({ test }) => test(value));
     if (!entry) {

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -140,6 +140,12 @@ export type Match<a, b> = {
   otherwise: <c>(handler: () => PickReturnValue<b, c>) => PickReturnValue<b, c>;
 
   /**
+   * ### Match.as
+   * Sets the return value type to a given type.
+   */
+  as: <c>() => Match<a, PickReturnValue<b, c>>;
+
+  /**
    * ### Match.run
    * Runs the pattern matching and return a value.
    * */

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -252,7 +252,7 @@ describe('types', () => {
       .run();
   });
 
-  describe('Unknown Input', () => {
+  it('Unknown Input', () => {
     const users: unknown = [{ name: 'Gabriel', postCount: 20 }];
 
     const typedUsers = match(users)
@@ -267,4 +267,15 @@ describe('types', () => {
         .join('')
     ).toEqual(`<p>Gabriel has 20 posts.</p>`);
   });
+
+
+  it('Can set return type', () => {
+    const v = 'dt' as 'dt' | 'num' | 'nil';
+    match(v)
+      .as<Date | number | undefined>()
+      .with('dt', () => new Date())
+      .with('num', () => 42)
+      .with('nil', () => undefined)
+      .run();
+  })
 });


### PR DESCRIPTION
Consider the following use case:

```typescript
    const v = 'dt' as 'dt' | 'num' | 'nil';
    match(v)
      .with('dt', () => new Date())
      .with('num', () => 42)
      .with('nil', () => undefined)
      .run();
```

Unefortunately, the first type is picked, trigerring an error on `42` and `undefined`.

I know I could do something like this:
```typescript
match<typeof v, Date | number | undefined>(v)
```
... but I'm finding it a bit verbose, and forces me to store the matched value in a local variable (or have a named type for its value).


One option could be to make `PickReturnValue` use unions instead of just propagating the same type. However, I feel this could lead to unexpected quite complex types being infered when there actually is a mistake in one branch.

That's why this PR suggests another approach: Adding an `as<v>()` method that forces all branches to a given return type.

Tell me what you think of it ! (no problem if you dont want to merge it :) )