### PR TITLE
Exhaustive pattern

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
   not,
   select,
 } from './types/Pattern';
-import { Unset, Match, PickReturnValue } from './types/Match';
+import { Unset, Match, PickReturnValue, ExcludePattern } from './types/Match';
 
 /**
  * # Pattern matching
@@ -44,7 +44,7 @@ const builder = <a, b>(
   with<p extends Pattern<a>, c>(
     pattern: p,
     ...args: any[]
-  ): Match<a, PickReturnValue<b, c>> {
+  ): any {
     const handler = args[args.length - 1];
     const predicates = args.slice(0, -1);
 
@@ -54,7 +54,7 @@ const builder = <a, b>(
           predicates.every((predicate) => predicate(value as any))
       );
 
-    return builder<a, PickReturnValue<b, c>>(value, [
+    return builder<ExcludePattern<a, p>, PickReturnValue<b, c>>(value as any, [
       ...patterns,
       {
         test: doesMatch,
@@ -76,6 +76,9 @@ const builder = <a, b>(
         select: () => ({}),
       },
     ]),
+
+  exhaustive: ((): Match<a, b>  =>
+    builder<a, b>(value, patterns)) as any,
 
   otherwise: <c>(handler: () => PickReturnValue<b, c>): PickReturnValue<b, c> =>
     builder<a, PickReturnValue<b, c>>(value, [

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -58,6 +58,8 @@ export type Unset = '@match/unset';
 
 export type PickReturnValue<a, b> = a extends Unset ? b : a;
 
+export type ExcludePattern<a, p> = a extends string ? Exclude<a, p> : a;
+
 /**
  * ### Match
  * An interface to create a pattern matching clause.
@@ -74,7 +76,7 @@ export type Match<a, b> = {
       value: MatchedValue<a, p>,
       selections: ExtractSelections<a, p>
     ) => PickReturnValue<b, c>
-  ): Match<a, PickReturnValue<b, c>>;
+  ): Match<ExcludePattern<a, p>, PickReturnValue<b, c>>;
   with<
     pat extends Pattern<a>,
     pred extends (value: MatchedValue<a, pat>) => unknown,
@@ -144,4 +146,13 @@ export type Match<a, b> = {
    * Runs the pattern matching and return a value.
    * */
   run: () => b;
+
+  /**
+   * ### Match.exhaustive
+   * Will yield a type error if all cases have not been handled
+   *
+   * nb: Only works when the matched value extends string
+   */
+  exhaustive: [a] extends [never] ? () => Match<a, b>
+  : never;
 };

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -58,7 +58,15 @@ export type Unset = '@match/unset';
 
 export type PickReturnValue<a, b> = a extends Unset ? b : a;
 
-export type ExcludePattern<a, p> = a extends string ? Exclude<a, p> : a;
+
+type ExcludeString<a extends string, p>
+  = p extends string ? Exclude<a, p>
+  : a;
+export type ExcludePattern<a, p> = a extends string
+  ? ExcludeString<a, p>
+  : a;
+
+type NonExhaustivePattern = {__nonExhaustive: never};
 
 /**
  * ### Match
@@ -154,5 +162,5 @@ export type Match<a, b> = {
    * nb: Only works when the matched value extends string
    */
   exhaustive: [a] extends [never] ? () => Match<a, b>
-  : never;
+  : NonExhaustivePattern;
 };

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -4,6 +4,21 @@ import { State, Event, NotNever } from './utils';
 describe('types', () => {
   type Input = [State, Event];
 
+  it ('Can force exhaustive pattern', () => {
+    const v = 'dt' as 'dt' | 'num' | 'nil';
+    const matcher = match(v)
+      .with('dt', () => 1)
+      .with('num', () => 2);
+
+    // @ts-expect-error
+    matcher.exhaustive().run();
+
+    matcher
+      .with('nil', () => 3)
+      .exhaustive()
+      .run();
+  });
+
   it('wildcard patterns should typecheck', () => {
     let pattern: Pattern<Input>;
     pattern = __;


### PR DESCRIPTION
Implements exhaustive pattern matching (at least on types that extend string)

![image](https://user-images.githubusercontent.com/8973947/100394904-1480f280-303f-11eb-9083-68f718c8e89f.png)


[edit] It turns out that i'm not the only one wishing that :)  cf. #4 , and i've seen that you've mentioned something like this in roadmap.md ... is that the kind of thing that you have in mind ?

nb: I introduced this new `otherwise()` function (which does essentially nothing except type checking) because the versatility of various pattern matching overloads is such that I think it is be impossible to implement exhaustive check on `.run()`,  (i'm looking right at you, predicates...), so I only see this exclusive matching as an opt-in behaviour.

(again, no pressure to merge this, I wont take it personally if you're going another way)