### PR TITLE
Improve perfs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lib
 notes.md
 .vscode/
 tracing_output_folder/
+*.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "2.1.1-next.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "2.1.0",
+  "version": "2.1.1-next.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "2.1.0",
+  "version": "2.1.1-next.0",
   "description": "Typescript pattern matching library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "2.1.1-next.0",
+  "version": "2.1.1",
   "description": "Typescript pattern matching library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types/DistributeUnions.ts
+++ b/src/types/DistributeUnions.ts
@@ -8,6 +8,7 @@ import type {
   Drop,
   Iterator,
   Next,
+  IsPlainObject,
 } from './helpers';
 
 /**
@@ -93,7 +94,7 @@ export type FindUnions<a, path extends PropertyKey[] = []> = IsUnion<
   ? []
   : a extends Map<any, any>
   ? []
-  : a extends object
+  : IsPlainObject<a> extends true
   ? Flatten<
       Values<
         {

--- a/src/types/DistributeUnions.ts
+++ b/src/types/DistributeUnions.ts
@@ -53,8 +53,8 @@ export type DistributeUnions<a> = IsAny<a> extends true
  * FindUnions :: a -> UnionConfig[]
  */
 export type FindUnions<a, path extends PropertyKey[] = []> =
-  // Don't try to find unions after 3 levels
-  Length<path> extends 3
+  // Don't try to find unions after 4 levels
+  Length<path> extends 4
     ? []
     : IsUnion<a> extends true
     ? [

--- a/src/types/ExtractPreciseValue.ts
+++ b/src/types/ExtractPreciseValue.ts
@@ -1,6 +1,10 @@
 import type { PatternType, __ } from '../PatternType';
 import type { Primitives } from './Pattern';
-import type { ExcludeIfContainsNever, LeastUpperBound } from './helpers';
+import type {
+  ExcludeIfContainsNever,
+  IsPlainObject,
+  LeastUpperBound,
+} from './helpers';
 
 export type ExtractPreciseValue<a, b> = ExcludeIfContainsNever<
   b extends []
@@ -52,7 +56,7 @@ export type ExtractPreciseValue<a, b> = ExcludeIfContainsNever<
     ? a extends Set<infer av>
       ? Set<ExtractPreciseValue<av, bv>>
       : LeastUpperBound<a, b>
-    : b extends object
+    : IsPlainObject<b> extends true
     ? a extends any[] | Set<any> | Map<any, any> | Primitives
       ? LeastUpperBound<a, b>
       : b extends a

--- a/src/types/InvertPattern.ts
+++ b/src/types/InvertPattern.ts
@@ -1,4 +1,5 @@
 import type { PatternType, __ } from '../PatternType';
+import { IsPlainObject } from './helpers';
 import type {
   SelectPattern,
   GuardPattern,
@@ -55,6 +56,6 @@ export type InvertPattern<p> = p extends typeof __.number
   ? Map<pk, InvertPattern<pv>>
   : p extends Set<infer pv>
   ? Set<InvertPattern<pv>>
-  : p extends object
+  : IsPlainObject<p> extends true
   ? { [k in keyof p]: InvertPattern<p[k]> }
   : p;

--- a/src/types/Pattern.ts
+++ b/src/types/Pattern.ts
@@ -1,4 +1,5 @@
 import type { __, PatternType } from '../PatternType';
+import { IsPlainObject } from './helpers';
 
 export type Primitives =
   | number
@@ -77,7 +78,7 @@ export type Pattern<a> =
       ? Map<k, Pattern<v>>
       : a extends Set<infer v>
       ? Set<Pattern<v>>
-      : a extends object
+      : IsPlainObject<a> extends true
       ? { [k in keyof a]?: Pattern<a[k]> }
       : a);
 
@@ -133,6 +134,6 @@ export type ExhaustivePattern<a> =
       ? Map<k, ExhaustivePattern<v>>
       : a extends Set<infer v>
       ? Set<ExhaustivePattern<v>>
-      : a extends object
+      : IsPlainObject<a> extends true
       ? { [k in keyof a]?: ExhaustivePattern<a[k]> }
       : a);

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -21,8 +21,8 @@ export type ExcludeIfContainsNever<a> = a extends Map<any, any> | Set<any>
   ? a
   : a extends any[]
   ? ExcludeNeverArray<a>
-  : a extends object
-  ? ExcludeNeverObject<a>
+  : IsPlainObject<a> extends true
+  ? ExcludeNeverObject<Cast<a, object>>
   : a;
 
 type ExcludeNeverArray<a extends any[]> =
@@ -62,7 +62,7 @@ export type IsUnion<a> = [a] extends [UnionToIntersection<a>] ? false : true;
 
 export type ContainsUnion<a> = IsUnion<a> extends true
   ? true
-  : a extends object
+  : IsPlainObject<a> extends true
   ? false extends ValueOf<{ [k in keyof a]: ContainsUnion<a[k]> }>
     ? false
     : true
@@ -78,7 +78,7 @@ type RemoveNeverKeys<o> = Omit<o, NeverKeys<o>>;
 
 export type ExcludeUnion<a> = IsUnion<a> extends true
   ? never
-  : a extends object
+  : IsPlainObject<a> extends true
   ? RemoveNeverKeys<{ [k in keyof a]: ExcludeUnion<a[k]> }>
   : a;
 
@@ -127,3 +127,17 @@ export type Drop<xs extends any[], n extends any[]> = Length<n> extends 0
   : xs extends [any, ...(infer tail)]
   ? Drop<tail, Prev<n>>
   : [];
+
+type BuiltInObjects =
+  | Function
+  | Error
+  | Date
+  | RegExp
+  | Generator
+  | { readonly [Symbol.toStringTag]: string };
+
+export type IsPlainObject<o> = o extends object
+  ? o extends BuiltInObjects
+    ? false
+    : true
+  : false;

--- a/tests/distribute-unions.test.ts
+++ b/tests/distribute-unions.test.ts
@@ -160,11 +160,8 @@ describe('FindUnions', () => {
         Equal<
           FindUnions<{
             a: {
-              b: {
-                c: {
-                  d: { e: 7 | 8; f: 9 | 10 };
-                };
-              };
+              e: 7 | 8;
+              f: 9 | 10;
             };
           }>,
           [
@@ -178,7 +175,7 @@ describe('FindUnions', () => {
                     value: 8;
                     subUnions: [];
                   };
-              path: ['a', 'b', 'c', 'd', 'e'];
+              path: ['a', 'e'];
             },
             {
               cases:
@@ -190,7 +187,7 @@ describe('FindUnions', () => {
                     value: 10;
                     subUnions: [];
                   };
-              path: ['a', 'b', 'c', 'd', 'f'];
+              path: ['a', 'f'];
             }
           ]
         >
@@ -198,15 +195,12 @@ describe('FindUnions', () => {
       Expect<
         Equal<
           FindUnions<{
+            e: 'not a union';
             a: {
-              b: {
-                c: {
-                  d: { e: 7 | 8; f: 9 | 10 };
-                  e: 'not a union';
-                };
-                g: 2 | 3;
-              };
+              e: 7 | 8;
+              f: 9 | 10;
             };
+            b: 2 | 3;
           }>,
           [
             {
@@ -219,7 +213,7 @@ describe('FindUnions', () => {
                     value: 8;
                     subUnions: [];
                   };
-              path: ['a', 'b', 'c', 'd', 'e'];
+              path: ['a', 'e'];
             },
             {
               cases:
@@ -231,7 +225,7 @@ describe('FindUnions', () => {
                     value: 10;
                     subUnions: [];
                   };
-              path: ['a', 'b', 'c', 'd', 'f'];
+              path: ['a', 'f'];
             },
             {
               cases:
@@ -243,7 +237,7 @@ describe('FindUnions', () => {
                     value: 3;
                     subUnions: [];
                   };
-              path: ['a', 'b', 'g'];
+              path: ['b'];
             }
           ]
         >

--- a/tests/distribute-unions.test.ts
+++ b/tests/distribute-unions.test.ts
@@ -160,8 +160,10 @@ describe('FindUnions', () => {
         Equal<
           FindUnions<{
             a: {
-              e: 7 | 8;
-              f: 9 | 10;
+              b: {
+                e: 7 | 8;
+                f: 9 | 10;
+              };
             };
           }>,
           [
@@ -175,7 +177,7 @@ describe('FindUnions', () => {
                     value: 8;
                     subUnions: [];
                   };
-              path: ['a', 'e'];
+              path: ['a', 'b', 'e'];
             },
             {
               cases:
@@ -187,7 +189,7 @@ describe('FindUnions', () => {
                     value: 10;
                     subUnions: [];
                   };
-              path: ['a', 'f'];
+              path: ['a', 'b', 'f'];
             }
           ]
         >


### PR DESCRIPTION
Some small typechecking perf improvements

- Only recurse on plain objects
- Stop recursion after 4 level of nesting in `DistributeUnions<a>` to avoid unnecessarily traversing huge data structures looking for union types