### PR TITLE
Gabriel.vergnaud/better exhaustive matching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "2.1.2",
+  "version": "2.1.3-next.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "2.1.2",
+  "version": "2.1.3-next.0",
   "description": "Typescript pattern matching library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/PatternType.ts
+++ b/src/PatternType.ts
@@ -1,10 +1,10 @@
 export enum PatternType {
-  String = '@match/string',
-  Number = '@match/number',
-  Boolean = '@match/boolean',
-  Guard = '@match/guard',
-  Not = '@match/not',
-  Select = '@match/select',
+  String = '@ts-pattern/string',
+  Number = '@ts-pattern/number',
+  Boolean = '@ts-pattern/boolean',
+  Guard = '@ts-pattern/guard',
+  Not = '@ts-pattern/not',
+  Select = '@ts-pattern/select',
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,6 @@ import type {
 } from './types/Match';
 
 import { __, PatternType } from './PatternType';
-import { DistributeUnions } from './types/DistributeUnions';
 
 export const when = <a, b extends a = a>(
   predicate: GuardFunction<a, b>
@@ -132,8 +131,7 @@ const builder = <a, b>(
    * that **all cases are handled**. `when` predicates
    * aren't supported on exhaustive matches.
    **/
-  exhaustive: (): ExhaustiveMatch<DistributeUnions<a>, a, b> =>
-    builder(value, patterns) as any,
+  exhaustive: (): ExhaustiveMatch<a, a, b> => builder(value, patterns) as any,
 });
 
 const isObject = (value: unknown): value is Object =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,18 +21,18 @@ import { DistributeUnions } from './types/DistributeUnions';
 export const when = <a, b extends a = a>(
   predicate: GuardFunction<a, b>
 ): GuardPattern<a, b> => ({
-  __patternKind: PatternType.Guard,
-  __when: predicate,
+  '@ts-pattern/__patternKind': PatternType.Guard,
+  '@ts-pattern/__when': predicate,
 });
 
 export const not = <a>(pattern: Pattern<a>): NotPattern<a> => ({
-  __patternKind: PatternType.Not,
-  __pattern: pattern,
+  '@ts-pattern/__patternKind': PatternType.Not,
+  '@ts-pattern/__pattern': pattern,
 });
 
 export const select = <k extends string>(key: k): SelectPattern<k> => ({
-  __patternKind: PatternType.Select,
-  __key: key,
+  '@ts-pattern/__patternKind': PatternType.Select,
+  '@ts-pattern/__key': key,
 });
 
 /**
@@ -145,19 +145,19 @@ const isGuardPattern = (x: unknown): x is GuardPattern<unknown> => {
   const pattern = x as GuardPattern<unknown>;
   return (
     pattern &&
-    pattern.__patternKind === PatternType.Guard &&
-    typeof pattern.__when === 'function'
+    pattern['@ts-pattern/__patternKind'] === PatternType.Guard &&
+    typeof pattern['@ts-pattern/__when'] === 'function'
   );
 };
 
 const isNotPattern = (x: unknown): x is NotPattern<unknown> => {
   const pattern = x as NotPattern<unknown>;
-  return pattern && pattern.__patternKind === PatternType.Not;
+  return pattern && pattern['@ts-pattern/__patternKind'] === PatternType.Not;
 };
 
 const isSelectPattern = (x: unknown): x is SelectPattern<string> => {
   const pattern = x as SelectPattern<string>;
-  return pattern && pattern.__patternKind === PatternType.Select;
+  return pattern && pattern['@ts-pattern/__patternKind'] === PatternType.Select;
 };
 
 const isListPattern = (x: unknown): x is [Pattern<unknown>] => {
@@ -175,8 +175,10 @@ const matchPattern = <a, p extends Pattern<a>>(pattern: p) => (
   if (pattern === __.number) {
     return typeof value === 'number' && !Number.isNaN(value);
   }
-  if (isGuardPattern(pattern)) return Boolean(pattern.__when(value));
-  if (isNotPattern(pattern)) return !matchPattern(pattern.__pattern)(value);
+  if (isGuardPattern(pattern))
+    return Boolean(pattern['@ts-pattern/__when'](value));
+  if (isNotPattern(pattern))
+    return !matchPattern(pattern['@ts-pattern/__pattern'])(value);
   if (isListPattern(pattern) && isArray(value))
     return value.every((v) => matchPattern(pattern[0])(v));
 
@@ -220,7 +222,8 @@ const matchPattern = <a, p extends Pattern<a>>(pattern: p) => (
 const selectWithPattern = <a, p extends Pattern<a>>(pattern: p) => (
   value: a
 ): Record<string, unknown> => {
-  if (isSelectPattern(pattern)) return { [pattern.__key]: value };
+  if (isSelectPattern(pattern))
+    return { [pattern['@ts-pattern/__key']]: value };
 
   if (isListPattern(pattern) && isArray(value))
     return value

--- a/src/types/DeepExclude.ts
+++ b/src/types/DeepExclude.ts
@@ -1,3 +1,7 @@
 import { DistributeMatchingUnions } from './DistributeUnions';
+import { InvertNotPattern } from './InvertPattern';
 
-export type DeepExclude<i, p> = Exclude<DistributeMatchingUnions<i, p>, p>;
+export type DeepExclude<i, p> = Exclude<
+  DistributeMatchingUnions<i, p>,
+  InvertNotPattern<p, i>
+>;

--- a/src/types/DeepExclude.ts
+++ b/src/types/DeepExclude.ts
@@ -1,0 +1,3 @@
+import { DistributeMatchingUnions } from './DistributeUnions';
+
+export type DeepExclude<i, p> = Exclude<DistributeMatchingUnions<i, p>, p>;

--- a/src/types/DeepExclude.ts
+++ b/src/types/DeepExclude.ts
@@ -1,7 +1,3 @@
 import { DistributeMatchingUnions } from './DistributeUnions';
-import { InvertNotPattern } from './InvertPattern';
 
-export type DeepExclude<i, p> = Exclude<
-  DistributeMatchingUnions<i, p>,
-  InvertNotPattern<p, i>
->;
+export type DeepExclude<a, b> = Exclude<DistributeMatchingUnions<a, b>, b>;

--- a/src/types/DistributeUnions.ts
+++ b/src/types/DistributeUnions.ts
@@ -122,8 +122,8 @@ export type FindAllUnions<a, path extends PropertyKey[] = []> =
 export type FindUnions<a, p, path extends PropertyKey[] = []> = IsAny<
   p
 > extends true
-  ? [] // Don't try to find unions after 4 levels
-  : Length<path> extends 4
+  ? [] // Don't try to find unions after 5 levels
+  : Length<path> extends 5
   ? []
   : IsUnion<a> extends true
   ? [

--- a/src/types/DistributeUnions.ts
+++ b/src/types/DistributeUnions.ts
@@ -137,6 +137,8 @@ export type FindUnions<a, p, path extends PropertyKey[] = []> = IsAny<
         path: path;
       }
     ]
+  : IsMatching<a, p> extends false
+  ? []
   : [a, p] extends [any[], any[]]
   ? [a, p] extends [
       [infer a1, infer a2, infer a3, infer a4, infer a5],
@@ -177,20 +179,18 @@ export type FindUnions<a, p, path extends PropertyKey[] = []> = IsAny<
   ? []
   : [IsPlainObject<a>, IsPlainObject<p>] extends [true, true]
   ? Flatten<
-      IsMatching<a, p> extends true
-        ? Values<
-            {
-              // we use Required to remove the optional property modifier (?:).
-              // Optional properties aren't considered as union types to avoid
-              // generating a huge union.
-              [k in keyof Required<a> & keyof p]: FindUnions<
-                NonNullable<a[k]>,
-                p[k],
-                [...path, k]
-              >;
-            }
-          >
-        : []
+      Values<
+        {
+          // we use Required to remove the optional property modifier (?:).
+          // Optional properties aren't considered as union types to avoid
+          // generating a huge union.
+          [k in keyof Required<a> & keyof p]: FindUnions<
+            NonNullable<a[k]>,
+            p[k],
+            [...path, k]
+          >;
+        }
+      >
     >
   : [];
 

--- a/src/types/DistributeUnions.ts
+++ b/src/types/DistributeUnions.ts
@@ -13,7 +13,6 @@ import type {
   Compute,
 } from './helpers';
 import { IsMatching } from './IsMatching';
-import { Primitives } from './Pattern';
 
 /**
  * DistributeMatchingUnions takes two arguments:

--- a/src/types/DistributeUnions.ts
+++ b/src/types/DistributeUnions.ts
@@ -61,9 +61,13 @@ export type DistributeMatchingUnions<a, p> = IsAny<a> extends true
  * }
  * FindUnions :: Pattern a p => a -> p -> UnionConfig[]
  */
-export type FindUnions<a, p, path extends PropertyKey[] = []> = IsAny<
-  p
-> extends true
+export type FindUnions<
+  a,
+  p,
+  path extends PropertyKey[] = []
+> = unknown extends p
+  ? []
+  : IsAny<p> extends true
   ? [] // Don't try to find unions after 5 levels
   : Length<path> extends 5
   ? []

--- a/src/types/DistributeUnions.ts
+++ b/src/types/DistributeUnions.ts
@@ -117,6 +117,8 @@ export type FindUnions<
       ]
     : [a, p] extends [[infer a1, infer a2], [infer p1, infer p2]]
     ? [...FindUnions<a1, p1, [...path, 0]>, ...FindUnions<a2, p2, [...path, 1]>]
+    : [a, p] extends [[infer a1], [infer p1]]
+    ? FindUnions<a1, p1, [...path, 0]>
     : []
   : a extends Set<any>
   ? []

--- a/src/types/DistributeUnions.ts
+++ b/src/types/DistributeUnions.ts
@@ -40,7 +40,9 @@ import { IsMatching } from './IsMatching';
  */
 export type DistributeMatchingUnions<a, p> = IsAny<a> extends true
   ? any
-  : BuildMany<a, Distribute<FindUnions<a, p>>>;
+  : IsMatching<a, p> extends true
+  ? BuildMany<a, Distribute<FindUnions<a, p>>>
+  : a;
 
 /**
  * The reason we don't look further down the tree with lists,

--- a/src/types/DistributeUnions.ts
+++ b/src/types/DistributeUnions.ts
@@ -131,14 +131,14 @@ export type FindUnions<a, p, path extends PropertyKey[] = []> = IsAny<
         cases: a extends any
           ? {
               value: a;
-              subUnions: FindUnions<a, p, path>;
+              subUnions: IsMatching<a, p> extends true
+                ? FindUnions<a, p, path>
+                : [];
             }
           : never;
         path: path;
       }
     ]
-  : IsMatching<a, p> extends false
-  ? []
   : [a, p] extends [any[], any[]]
   ? [a, p] extends [
       [infer a1, infer a2, infer a3, infer a4, infer a5],

--- a/src/types/ExtractPreciseValue.ts
+++ b/src/types/ExtractPreciseValue.ts
@@ -7,70 +7,68 @@ import type {
   LeastUpperBound,
 } from './helpers';
 
-export type ExtractPreciseValue<a, b> = IsAny<b> extends true
-  ? a
-  : ExcludeIfContainsNever<
-      b extends []
-        ? []
-        : b extends { valueKind: PatternType.Not; value: infer b1 }
-        ? Exclude<a, b1>
-        : b extends (infer bItem)[]
-        ? a extends (infer aItem)[]
-          ? b extends [infer b1, infer b2, infer b3, infer b4, infer b5]
-            ? a extends [infer a1, infer a2, infer a3, infer a4, infer a5]
-              ? [
-                  ExtractPreciseValue<a1, b1>,
-                  ExtractPreciseValue<a2, b2>,
-                  ExtractPreciseValue<a3, b3>,
-                  ExtractPreciseValue<a4, b4>,
-                  ExtractPreciseValue<a5, b5>
-                ]
-              : LeastUpperBound<a, b>
-            : b extends [infer b1, infer b2, infer b3, infer b4]
-            ? a extends [infer a1, infer a2, infer a3, infer a4]
-              ? [
-                  ExtractPreciseValue<a1, b1>,
-                  ExtractPreciseValue<a2, b2>,
-                  ExtractPreciseValue<a3, b3>,
-                  ExtractPreciseValue<a4, b4>
-                ]
-              : LeastUpperBound<a, b>
-            : b extends [infer b1, infer b2, infer b3]
-            ? a extends [infer a1, infer a2, infer a3]
-              ? [
-                  ExtractPreciseValue<a1, b1>,
-                  ExtractPreciseValue<a2, b2>,
-                  ExtractPreciseValue<a3, b3>
-                ]
-              : LeastUpperBound<a, b>
-            : b extends [infer b1, infer b2]
-            ? a extends [infer a1, infer a2]
-              ? [ExtractPreciseValue<a1, b1>, ExtractPreciseValue<a2, b2>]
-              : LeastUpperBound<a, b>
-            : ExtractPreciseValue<aItem, bItem>[]
+export type ExtractPreciseValue<a, b> = ExcludeIfContainsNever<
+  b extends []
+    ? []
+    : b extends { valueKind: PatternType.Not; value: infer b1 }
+    ? Exclude<a, b1>
+    : b extends (infer bItem)[]
+    ? a extends (infer aItem)[]
+      ? b extends [infer b1, infer b2, infer b3, infer b4, infer b5]
+        ? a extends [infer a1, infer a2, infer a3, infer a4, infer a5]
+          ? [
+              ExtractPreciseValue<a1, b1>,
+              ExtractPreciseValue<a2, b2>,
+              ExtractPreciseValue<a3, b3>,
+              ExtractPreciseValue<a4, b4>,
+              ExtractPreciseValue<a5, b5>
+            ]
           : LeastUpperBound<a, b>
-        : b extends Map<infer bk, infer bv>
-        ? a extends Map<infer ak, infer av>
-          ? Map<ExtractPreciseValue<ak, bk>, ExtractPreciseValue<av, bv>>
+        : b extends [infer b1, infer b2, infer b3, infer b4]
+        ? a extends [infer a1, infer a2, infer a3, infer a4]
+          ? [
+              ExtractPreciseValue<a1, b1>,
+              ExtractPreciseValue<a2, b2>,
+              ExtractPreciseValue<a3, b3>,
+              ExtractPreciseValue<a4, b4>
+            ]
           : LeastUpperBound<a, b>
-        : b extends Set<infer bv>
-        ? a extends Set<infer av>
-          ? Set<ExtractPreciseValue<av, bv>>
+        : b extends [infer b1, infer b2, infer b3]
+        ? a extends [infer a1, infer a2, infer a3]
+          ? [
+              ExtractPreciseValue<a1, b1>,
+              ExtractPreciseValue<a2, b2>,
+              ExtractPreciseValue<a3, b3>
+            ]
           : LeastUpperBound<a, b>
-        : IsPlainObject<b> extends true
-        ? a extends any[] | Set<any> | Map<any, any> | Primitives
-          ? LeastUpperBound<a, b>
-          : b extends a
-          ? b
-          : a extends b
-          ? a
-          : {
-              // we use Required to remove the optional property modifier (?:).
-              // since we use a[k] after that, optional properties will stay
-              // optional if no pattern was more precise.
-              [k in keyof Required<a>]: k extends keyof b
-                ? ExtractPreciseValue<a[k], b[k]>
-                : a[k];
-            }
-        : LeastUpperBound<a, b>
-    >;
+        : b extends [infer b1, infer b2]
+        ? a extends [infer a1, infer a2]
+          ? [ExtractPreciseValue<a1, b1>, ExtractPreciseValue<a2, b2>]
+          : LeastUpperBound<a, b>
+        : ExtractPreciseValue<aItem, bItem>[]
+      : LeastUpperBound<a, b>
+    : b extends Map<infer bk, infer bv>
+    ? a extends Map<infer ak, infer av>
+      ? Map<ExtractPreciseValue<ak, bk>, ExtractPreciseValue<av, bv>>
+      : LeastUpperBound<a, b>
+    : b extends Set<infer bv>
+    ? a extends Set<infer av>
+      ? Set<ExtractPreciseValue<av, bv>>
+      : LeastUpperBound<a, b>
+    : IsPlainObject<b> extends true
+    ? a extends any[] | Set<any> | Map<any, any> | Primitives
+      ? LeastUpperBound<a, b>
+      : b extends a
+      ? b
+      : a extends b
+      ? a
+      : {
+          // we use Required to remove the optional property modifier (?:).
+          // since we use a[k] after that, optional properties will stay
+          // optional if no pattern was more precise.
+          [k in keyof Required<a>]: k extends keyof b
+            ? ExtractPreciseValue<a[k], b[k]>
+            : a[k];
+        }
+    : LeastUpperBound<a, b>
+>;

--- a/src/types/ExtractPreciseValue.ts
+++ b/src/types/ExtractPreciseValue.ts
@@ -1,5 +1,5 @@
 import type { PatternType, __ } from '../PatternType';
-import type { Primitives } from './Pattern';
+import type { NotPattern, Primitives } from './Pattern';
 import type {
   ExcludeIfContainsNever,
   IsAny,
@@ -10,7 +10,7 @@ import type {
 export type ExtractPreciseValue<a, b> = ExcludeIfContainsNever<
   b extends []
     ? []
-    : b extends { valueKind: PatternType.Not; value: infer b1 }
+    : b extends NotPattern<infer b1>
     ? Exclude<a, b1>
     : b extends (infer bItem)[]
     ? a extends (infer aItem)[]

--- a/src/types/ExtractPreciseValue.ts
+++ b/src/types/ExtractPreciseValue.ts
@@ -1,13 +1,13 @@
 import type { PatternType, __ } from '../PatternType';
 import type { Primitives } from './Pattern';
-import { PatternPlaceholder } from './InvertPattern';
 import type {
   ExcludeIfContainsNever,
+  IsAny,
   IsPlainObject,
   LeastUpperBound,
 } from './helpers';
 
-export type ExtractPreciseValue<a, b> = b extends PatternPlaceholder
+export type ExtractPreciseValue<a, b> = IsAny<b> extends true
   ? a
   : ExcludeIfContainsNever<
       b extends []

--- a/src/types/ExtractPreciseValue.ts
+++ b/src/types/ExtractPreciseValue.ts
@@ -6,68 +6,79 @@ import type {
   LeastUpperBound,
 } from './helpers';
 
-export type ExtractPreciseValue<a, b> = ExcludeIfContainsNever<
-  b extends []
-    ? []
-    : b extends NotPattern<infer b1>
-    ? Exclude<a, b1>
-    : b extends (infer bItem)[]
-    ? a extends (infer aItem)[]
-      ? b extends [infer b1, infer b2, infer b3, infer b4, infer b5]
-        ? a extends [infer a1, infer a2, infer a3, infer a4, infer a5]
-          ? [
-              ExtractPreciseValue<a1, b1>,
-              ExtractPreciseValue<a2, b2>,
-              ExtractPreciseValue<a3, b3>,
-              ExtractPreciseValue<a4, b4>,
-              ExtractPreciseValue<a5, b5>
-            ]
+export type ExtractPreciseValue<a, b> =
+  /**
+   * we handle the `unknown` type separately because
+   * the `ExcludeIfContainsNever<...>` type doesn't
+   * reduce with type variables (foralls).
+   * We want it to at least reduce on wildcard patterns
+   * (we know it is going to evaluate to the input type)
+   * and `unknown` is the inverted type of wildcard patterns.
+   */
+  unknown extends b
+    ? a
+    : ExcludeIfContainsNever<
+        b extends []
+          ? []
+          : b extends NotPattern<infer b1>
+          ? Exclude<a, b1>
+          : b extends (infer bItem)[]
+          ? a extends (infer aItem)[]
+            ? b extends [infer b1, infer b2, infer b3, infer b4, infer b5]
+              ? a extends [infer a1, infer a2, infer a3, infer a4, infer a5]
+                ? [
+                    ExtractPreciseValue<a1, b1>,
+                    ExtractPreciseValue<a2, b2>,
+                    ExtractPreciseValue<a3, b3>,
+                    ExtractPreciseValue<a4, b4>,
+                    ExtractPreciseValue<a5, b5>
+                  ]
+                : LeastUpperBound<a, b>
+              : b extends [infer b1, infer b2, infer b3, infer b4]
+              ? a extends [infer a1, infer a2, infer a3, infer a4]
+                ? [
+                    ExtractPreciseValue<a1, b1>,
+                    ExtractPreciseValue<a2, b2>,
+                    ExtractPreciseValue<a3, b3>,
+                    ExtractPreciseValue<a4, b4>
+                  ]
+                : LeastUpperBound<a, b>
+              : b extends [infer b1, infer b2, infer b3]
+              ? a extends [infer a1, infer a2, infer a3]
+                ? [
+                    ExtractPreciseValue<a1, b1>,
+                    ExtractPreciseValue<a2, b2>,
+                    ExtractPreciseValue<a3, b3>
+                  ]
+                : LeastUpperBound<a, b>
+              : b extends [infer b1, infer b2]
+              ? a extends [infer a1, infer a2]
+                ? [ExtractPreciseValue<a1, b1>, ExtractPreciseValue<a2, b2>]
+                : LeastUpperBound<a, b>
+              : ExtractPreciseValue<aItem, bItem>[]
+            : LeastUpperBound<a, b>
+          : b extends Map<infer bk, infer bv>
+          ? a extends Map<infer ak, infer av>
+            ? Map<ExtractPreciseValue<ak, bk>, ExtractPreciseValue<av, bv>>
+            : LeastUpperBound<a, b>
+          : b extends Set<infer bv>
+          ? a extends Set<infer av>
+            ? Set<ExtractPreciseValue<av, bv>>
+            : LeastUpperBound<a, b>
+          : IsPlainObject<b> extends true
+          ? a extends any[] | Set<any> | Map<any, any> | Primitives
+            ? LeastUpperBound<a, b>
+            : b extends a
+            ? b
+            : a extends b
+            ? a
+            : {
+                // we use Required to remove the optional property modifier (?:).
+                // since we use a[k] after that, optional properties will stay
+                // optional if no pattern was more precise.
+                [k in keyof Required<a>]: k extends keyof b
+                  ? ExtractPreciseValue<a[k], b[k]>
+                  : a[k];
+              }
           : LeastUpperBound<a, b>
-        : b extends [infer b1, infer b2, infer b3, infer b4]
-        ? a extends [infer a1, infer a2, infer a3, infer a4]
-          ? [
-              ExtractPreciseValue<a1, b1>,
-              ExtractPreciseValue<a2, b2>,
-              ExtractPreciseValue<a3, b3>,
-              ExtractPreciseValue<a4, b4>
-            ]
-          : LeastUpperBound<a, b>
-        : b extends [infer b1, infer b2, infer b3]
-        ? a extends [infer a1, infer a2, infer a3]
-          ? [
-              ExtractPreciseValue<a1, b1>,
-              ExtractPreciseValue<a2, b2>,
-              ExtractPreciseValue<a3, b3>
-            ]
-          : LeastUpperBound<a, b>
-        : b extends [infer b1, infer b2]
-        ? a extends [infer a1, infer a2]
-          ? [ExtractPreciseValue<a1, b1>, ExtractPreciseValue<a2, b2>]
-          : LeastUpperBound<a, b>
-        : ExtractPreciseValue<aItem, bItem>[]
-      : LeastUpperBound<a, b>
-    : b extends Map<infer bk, infer bv>
-    ? a extends Map<infer ak, infer av>
-      ? Map<ExtractPreciseValue<ak, bk>, ExtractPreciseValue<av, bv>>
-      : LeastUpperBound<a, b>
-    : b extends Set<infer bv>
-    ? a extends Set<infer av>
-      ? Set<ExtractPreciseValue<av, bv>>
-      : LeastUpperBound<a, b>
-    : IsPlainObject<b> extends true
-    ? a extends any[] | Set<any> | Map<any, any> | Primitives
-      ? LeastUpperBound<a, b>
-      : b extends a
-      ? b
-      : a extends b
-      ? a
-      : {
-          // we use Required to remove the optional property modifier (?:).
-          // since we use a[k] after that, optional properties will stay
-          // optional if no pattern was more precise.
-          [k in keyof Required<a>]: k extends keyof b
-            ? ExtractPreciseValue<a[k], b[k]>
-            : a[k];
-        }
-    : LeastUpperBound<a, b>
->;
+      >;

--- a/src/types/ExtractPreciseValue.ts
+++ b/src/types/ExtractPreciseValue.ts
@@ -1,4 +1,3 @@
-import type { PatternType, __ } from '../PatternType';
 import type { NotPattern, Primitives } from './Pattern';
 import type {
   ExcludeIfContainsNever,

--- a/src/types/ExtractPreciseValue.ts
+++ b/src/types/ExtractPreciseValue.ts
@@ -2,7 +2,6 @@ import type { PatternType, __ } from '../PatternType';
 import type { NotPattern, Primitives } from './Pattern';
 import type {
   ExcludeIfContainsNever,
-  IsAny,
   IsPlainObject,
   LeastUpperBound,
 } from './helpers';

--- a/src/types/FindSelected.ts
+++ b/src/types/FindSelected.ts
@@ -1,12 +1,12 @@
 import type { SelectPattern } from './Pattern';
 import type { ValueOf } from './helpers';
 
-export type FindSelected<a, b> = b extends SelectPattern<infer Key>
-  ? { [k in Key]: a }
-  : [a, b] extends [(infer aa)[], [infer p]]
-  ? FindSelected<aa, p> extends infer selected
+export type FindSelected<i, p> = p extends SelectPattern<infer Key>
+  ? { [k in Key]: i }
+  : [i, p] extends [(infer i2)[], [infer p2]]
+  ? FindSelected<i2, p2> extends infer selected
     ? { [k in keyof selected]: selected[k][] }
     : never
-  : [a, b] extends [object, object]
-  ? ValueOf<{ [k in keyof a & keyof b]: FindSelected<a[k], b[k]> }>
+  : [i, p] extends [object, object]
+  ? ValueOf<{ [k in keyof i & keyof p]: FindSelected<i[k], p[k]> }>
   : never;

--- a/src/types/InvertPattern.ts
+++ b/src/types/InvertPattern.ts
@@ -19,9 +19,9 @@ export type InvertPattern<p> = p extends typeof __.number
   : p extends typeof __.boolean
   ? boolean
   : p extends SelectPattern<string>
-  ? any
+  ? unknown
   : p extends typeof __
-  ? any
+  ? unknown
   : p extends GuardPattern<any, infer pb>
   ? pb
   : p extends NotPattern<infer pb>

--- a/src/types/InvertPattern.ts
+++ b/src/types/InvertPattern.ts
@@ -57,6 +57,15 @@ export type InvertPattern<p> = p extends typeof __.number
   ? { [k in keyof p]: InvertPattern<p[k]> }
   : p;
 
+/**
+ * ### InvertNotPattern
+ * This generic takes the inverted pattern `p` and the input `i`
+ * and eliminates `NotPattern`s from `p`.
+ *
+ * It's separated from InvertPattern<p> because it's
+ * expensive to compute, and is only required by `DeepExclude`
+ * on exhaustive pattern matching.
+ */
 export type InvertNotPattern<p, i> = p extends NotPattern<infer p1>
   ? Exclude<i, p1>
   : p extends (infer pp)[]

--- a/src/types/InvertPattern.ts
+++ b/src/types/InvertPattern.ts
@@ -7,8 +7,6 @@ import type {
   Primitives,
 } from './Pattern';
 
-export type PatternPlaceholder = { __placeholder: '@match/placeholder' };
-
 /**
  * ### InvertPattern
  * Since patterns have special wildcard values, we need a way
@@ -21,9 +19,9 @@ export type InvertPattern<p> = p extends typeof __.number
   : p extends typeof __.boolean
   ? boolean
   : p extends SelectPattern<string>
-  ? PatternPlaceholder
+  ? any
   : p extends typeof __
-  ? PatternPlaceholder
+  ? any
   : p extends GuardPattern<any, infer pb>
   ? pb
   : p extends NotPattern<infer pb>

--- a/src/types/InvertPattern.ts
+++ b/src/types/InvertPattern.ts
@@ -1,4 +1,4 @@
-import type { PatternType, __ } from '../PatternType';
+import type { __ } from '../PatternType';
 import { IsPlainObject } from './helpers';
 import type {
   SelectPattern,

--- a/src/types/InvertPattern.ts
+++ b/src/types/InvertPattern.ts
@@ -22,35 +22,32 @@ export type InvertPattern<p> = p extends typeof __.number
   ? unknown
   : p extends typeof __
   ? unknown
-  : p extends GuardPattern<any, infer pb>
-  ? pb
-  : p extends NotPattern<infer pb>
-  ? {
-      valueKind: PatternType.Not;
-      value: InvertPattern<pb>;
-    }
+  : p extends GuardPattern<any, infer p1>
+  ? p1
+  : p extends NotPattern<infer a1>
+  ? NotPattern<InvertPattern<a1>>
   : p extends Primitives
   ? p
   : p extends (infer pp)[]
-  ? p extends [infer pb, infer pc, infer pd, infer pe, infer pf]
+  ? p extends [infer p1, infer p2, infer p3, infer p4, infer p5]
     ? [
-        InvertPattern<pb>,
-        InvertPattern<pc>,
-        InvertPattern<pd>,
-        InvertPattern<pe>,
-        InvertPattern<pf>
+        InvertPattern<p1>,
+        InvertPattern<p2>,
+        InvertPattern<p3>,
+        InvertPattern<p4>,
+        InvertPattern<p5>
       ]
-    : p extends [infer pb, infer pc, infer pd, infer pe]
+    : p extends [infer p1, infer p2, infer p3, infer p4]
     ? [
-        InvertPattern<pb>,
-        InvertPattern<pc>,
-        InvertPattern<pd>,
-        InvertPattern<pe>
+        InvertPattern<p1>,
+        InvertPattern<p2>,
+        InvertPattern<p3>,
+        InvertPattern<p4>
       ]
-    : p extends [infer pb, infer pc, infer pd]
-    ? [InvertPattern<pb>, InvertPattern<pc>, InvertPattern<pd>]
-    : p extends [infer pb, infer pc]
-    ? [InvertPattern<pb>, InvertPattern<pc>]
+    : p extends [infer p1, infer p2, infer p3]
+    ? [InvertPattern<p1>, InvertPattern<p2>, InvertPattern<p3>]
+    : p extends [infer p1, infer p2]
+    ? [InvertPattern<p1>, InvertPattern<p2>]
     : InvertPattern<pp>[]
   : p extends Map<infer pk, infer pv>
   ? Map<pk, InvertPattern<pv>>
@@ -58,4 +55,57 @@ export type InvertPattern<p> = p extends typeof __.number
   ? Set<InvertPattern<pv>>
   : IsPlainObject<p> extends true
   ? { [k in keyof p]: InvertPattern<p[k]> }
+  : p;
+
+export type InvertNotPattern<p, i> = p extends NotPattern<infer p1>
+  ? Exclude<i, p1>
+  : p extends (infer pp)[]
+  ? i extends (infer ii)[]
+    ? p extends [infer p1, infer p2, infer p3, infer p4, infer p5]
+      ? i extends [infer i1, infer i2, infer i3, infer i4, infer i5]
+        ? [
+            InvertNotPattern<p1, i1>,
+            InvertNotPattern<p2, i2>,
+            InvertNotPattern<p3, i3>,
+            InvertNotPattern<p4, i4>,
+            InvertNotPattern<p5, i5>
+          ]
+        : p
+      : p extends [infer p1, infer p2, infer p3, infer p4]
+      ? i extends [infer i1, infer i2, infer i3, infer i4]
+        ? [
+            InvertNotPattern<p1, i1>,
+            InvertNotPattern<p2, i2>,
+            InvertNotPattern<p3, i3>,
+            InvertNotPattern<p4, i4>
+          ]
+        : p
+      : p extends [infer p1, infer p2, infer p3]
+      ? i extends [infer i1, infer i2, infer i3]
+        ? [
+            InvertNotPattern<p1, i1>,
+            InvertNotPattern<p2, i2>,
+            InvertNotPattern<p3, i3>
+          ]
+        : p
+      : p extends [infer p1, infer p2]
+      ? i extends [infer i1, infer i2]
+        ? [InvertNotPattern<p1, i1>, InvertNotPattern<p2, i2>]
+        : p
+      : InvertNotPattern<pp, ii>[]
+    : p
+  : p extends Map<infer pk, infer pv>
+  ? i extends Map<any, infer iv>
+    ? Map<pk, InvertNotPattern<pv, iv>>
+    : p
+  : p extends Set<infer pv>
+  ? i extends Set<infer iv>
+    ? Set<InvertNotPattern<pv, iv>>
+    : p
+  : IsPlainObject<p> extends true
+  ? IsPlainObject<i> extends true
+    ? {
+        [k in keyof p]: k extends keyof i ? InvertNotPattern<p[k], i[k]> : p[k];
+      }
+    : p
   : p;

--- a/src/types/IsMatching.ts
+++ b/src/types/IsMatching.ts
@@ -1,5 +1,4 @@
 import { IsPlainObject, ValueOf, All } from './helpers';
-import { InvertPattern } from './InvertPattern';
 import { NotPattern, Primitives } from './Pattern';
 
 type Extends<a, b> = a extends b ? true : false;

--- a/src/types/IsMatching.ts
+++ b/src/types/IsMatching.ts
@@ -4,7 +4,7 @@ import { Primitives } from './Pattern';
 type Extends<a, b> = a extends b ? true : false;
 
 export type IsMatching<a, p> =
-  // Special case for unknown, because this the type
+  // Special case for unknown, because this is the type
   // of the inverted `__` wildcard pattern, which should
   // match everything.
   unknown extends p

--- a/src/types/IsMatching.ts
+++ b/src/types/IsMatching.ts
@@ -1,5 +1,5 @@
 import { IsPlainObject, ValueOf, All } from './helpers';
-import { NotPattern, Primitives } from './Pattern';
+import { Primitives } from './Pattern';
 
 type Extends<a, b> = a extends b ? true : false;
 

--- a/src/types/IsMatching.ts
+++ b/src/types/IsMatching.ts
@@ -3,48 +3,62 @@ import { NotPattern, Primitives } from './Pattern';
 
 type Extends<a, b> = a extends b ? true : false;
 
-export type IsMatching<a, p> = p extends Primitives
-  ? Extends<p, a>
-  : [a, p] extends [any[], any[]]
-  ? [a, p] extends [
-      [infer a1, infer a2, infer a3, infer a4, infer a5],
-      [infer p1, infer p2, infer p3, infer p4, infer p5]
-    ]
-    ? All<
-        [
-          IsMatching<a1, p1>,
-          IsMatching<a2, p2>,
-          IsMatching<a3, p3>,
-          IsMatching<a4, p4>,
-          IsMatching<a5, p5>
-        ]
-      >
-    : [a, p] extends [
-        [infer a1, infer a2, infer a3, infer a4],
-        [infer p1, infer p2, infer p3, infer p4]
+export type IsMatching<a, p> =
+  // Special case for unknown, because this the type
+  // of the inverted `__` wildcard pattern, which should
+  // match everything.
+  unknown extends p
+    ? true
+    : p extends Primitives
+    ? Extends<p, a>
+    : [a, p] extends [any[], any[]]
+    ? [a, p] extends [
+        [infer a1, infer a2, infer a3, infer a4, infer a5],
+        [infer p1, infer p2, infer p3, infer p4, infer p5]
       ]
-    ? All<
-        [
-          IsMatching<a1, p1>,
-          IsMatching<a2, p2>,
-          IsMatching<a3, p3>,
-          IsMatching<a4, p4>
+      ? All<
+          [
+            IsMatching<a1, p1>,
+            IsMatching<a2, p2>,
+            IsMatching<a3, p3>,
+            IsMatching<a4, p4>,
+            IsMatching<a5, p5>
+          ]
+        >
+      : [a, p] extends [
+          [infer a1, infer a2, infer a3, infer a4],
+          [infer p1, infer p2, infer p3, infer p4]
         ]
-      >
-    : [a, p] extends [
-        [infer a1, infer a2, infer a3],
-        [infer p1, infer p2, infer p3]
-      ]
-    ? All<[IsMatching<a1, p1>, IsMatching<a2, p2>, IsMatching<a3, p3>]>
-    : [a, p] extends [[infer a1, infer a2], [infer p1, infer p2]]
-    ? All<[IsMatching<a1, p1>, IsMatching<a2, p2>]>
-    : Extends<p, a>
-  : IsPlainObject<p> extends true
-  ? false extends ValueOf<
-      {
-        [k in keyof p & keyof a]: IsMatching<a[k], p[k]>;
-      }
-    >
-    ? false
-    : true
-  : Extends<p, a>;
+      ? All<
+          [
+            IsMatching<a1, p1>,
+            IsMatching<a2, p2>,
+            IsMatching<a3, p3>,
+            IsMatching<a4, p4>
+          ]
+        >
+      : [a, p] extends [
+          [infer a1, infer a2, infer a3],
+          [infer p1, infer p2, infer p3]
+        ]
+      ? All<[IsMatching<a1, p1>, IsMatching<a2, p2>, IsMatching<a3, p3>]>
+      : [a, p] extends [[infer a1, infer a2], [infer p1, infer p2]]
+      ? All<[IsMatching<a1, p1>, IsMatching<a2, p2>]>
+      : Extends<p, a>
+    : IsPlainObject<p> extends true
+    ? true extends (
+        // `true extends` means "if some cases of the a union are matching"
+        // loop over the `a` union
+        a extends any
+          ? ValueOf<
+              {
+                [k in keyof p & keyof a]: IsMatching<a[k], p[k]>;
+              }
+            > extends true
+            ? true // all values are matching
+            : false
+          : never
+      )
+      ? true
+      : false
+    : Extends<p, a>;

--- a/src/types/IsMatching.ts
+++ b/src/types/IsMatching.ts
@@ -47,14 +47,13 @@ export type IsMatching<a, p> =
       : Extends<p, a>
     : IsPlainObject<p> extends true
     ? true extends (
-        // `true extends` means "if some cases of the a union are matching"
-        // loop over the `a` union
-        a extends any
-          ? ValueOf<
-              {
-                [k in keyof p & keyof a]: IsMatching<a[k], p[k]>;
-              }
-            > extends true
+        // `true extends union` means "if some cases of the a union are matching"
+        a extends any // loop over the `a` union
+          ? [keyof p & keyof a] extends [never] // if no common keys
+            ? false
+            : ValueOf<
+                { [k in keyof p & keyof a]: IsMatching<a[k], p[k]> }
+              > extends true
             ? true // all values are matching
             : false
           : never

--- a/src/types/IsMatching.ts
+++ b/src/types/IsMatching.ts
@@ -44,6 +44,8 @@ export type IsMatching<a, p> =
       ? All<[IsMatching<a1, p1>, IsMatching<a2, p2>, IsMatching<a3, p3>]>
       : [a, p] extends [[infer a1, infer a2], [infer p1, infer p2]]
       ? All<[IsMatching<a1, p1>, IsMatching<a2, p2>]>
+      : [a, p] extends [[infer a1], [infer p1]]
+      ? All<[IsMatching<a1, p1>]>
       : Extends<p, a>
     : IsPlainObject<p> extends true
     ? true extends (

--- a/src/types/IsMatching.ts
+++ b/src/types/IsMatching.ts
@@ -1,0 +1,55 @@
+import { IsPlainObject, ValueOf, All } from './helpers';
+import { InvertPattern } from './InvertPattern';
+import { NotPattern, Primitives } from './Pattern';
+
+type Extends<a, b> = a extends b ? true : false;
+
+export type IsMatching<a, p> = p extends NotPattern<infer a2>
+  ? IsMatching<a, a2> extends true
+    ? false
+    : true
+  : p extends Primitives
+  ? Extends<p, a>
+  : [a, p] extends [any[], any[]]
+  ? [a, p] extends [
+      [infer a1, infer a2, infer a3, infer a4, infer a5],
+      [infer p1, infer p2, infer p3, infer p4, infer p5]
+    ]
+    ? All<
+        [
+          IsMatching<a1, p1>,
+          IsMatching<a2, p2>,
+          IsMatching<a3, p3>,
+          IsMatching<a4, p4>,
+          IsMatching<a5, p5>
+        ]
+      >
+    : [a, p] extends [
+        [infer a1, infer a2, infer a3, infer a4],
+        [infer p1, infer p2, infer p3, infer p4]
+      ]
+    ? All<
+        [
+          IsMatching<a1, p1>,
+          IsMatching<a2, p2>,
+          IsMatching<a3, p3>,
+          IsMatching<a4, p4>
+        ]
+      >
+    : [a, p] extends [
+        [infer a1, infer a2, infer a3],
+        [infer p1, infer p2, infer p3]
+      ]
+    ? All<[IsMatching<a1, p1>, IsMatching<a2, p2>, IsMatching<a3, p3>]>
+    : [a, p] extends [[infer a1, infer a2], [infer p1, infer p2]]
+    ? All<[IsMatching<a1, p1>, IsMatching<a2, p2>]>
+    : Extends<p, a>
+  : IsPlainObject<p> extends true
+  ? false extends ValueOf<
+      {
+        [k in keyof p & keyof a]: IsMatching<a[k], p[k]>;
+      }
+    >
+    ? false
+    : true
+  : Extends<p, a>;

--- a/src/types/IsMatching.ts
+++ b/src/types/IsMatching.ts
@@ -3,11 +3,7 @@ import { NotPattern, Primitives } from './Pattern';
 
 type Extends<a, b> = a extends b ? true : false;
 
-export type IsMatching<a, p> = p extends NotPattern<infer a2>
-  ? IsMatching<a, a2> extends true
-    ? false
-    : true
-  : p extends Primitives
+export type IsMatching<a, p> = p extends Primitives
   ? Extends<p, a>
   : [a, p] extends [any[], any[]]
   ? [a, p] extends [

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -1,6 +1,6 @@
 import type { Pattern, GuardValue, ExhaustivePattern } from './Pattern';
 import type { ExtractPreciseValue } from './ExtractPreciseValue';
-import type { InvertPattern } from './InvertPattern';
+import type { InvertNotPattern, InvertPattern } from './InvertPattern';
 import type { DeepExclude } from './DeepExclude';
 import type { UnionToIntersection } from './helpers';
 import type { FindSelected } from './FindSelected';
@@ -141,7 +141,7 @@ export type ExhaustiveMatch<distributedInput, i, o> = {
     // the distributedInput to ExhaustiveMatch, so we can compute the pattern
     // from the original input, which is much faster than computing it
     // from the distributed one.
-    DeepExclude<distributedInput, InvertPattern<p>>,
+    DeepExclude<distributedInput, InvertNotPattern<InvertPattern<p>, i>>,
     i,
     PickReturnValue<o, c>
   >;

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -17,7 +17,7 @@ export type ExtractSelections<a, p extends Pattern<a>> = UnionToIntersection<
   FindSelected<MatchedValue<a, p>, p>
 >;
 
-export type Unset = '@match/unset';
+export type Unset = '@ts-pattern/unset';
 
 export type PickReturnValue<a, b> = a extends Unset ? b : a;
 

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -4,7 +4,6 @@ import type { InvertNotPattern, InvertPattern } from './InvertPattern';
 import type { DeepExclude } from './DeepExclude';
 import type { UnionToIntersection, WithDefault } from './helpers';
 import type { FindSelected } from './FindSelected';
-import { __ } from '../PatternType';
 
 // We fall back to `a` if we weren't able to extract anything more precise
 export type MatchedValue<a, invpattern> = WithDefault<

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -1,7 +1,7 @@
 import type { Pattern, GuardValue, ExhaustivePattern } from './Pattern';
 import type { ExtractPreciseValue } from './ExtractPreciseValue';
 import type { InvertPattern } from './InvertPattern';
-import type { DistributeUnions } from './DistributeUnions';
+import type { DeepExclude } from './DeepExclude';
 import type { UnionToIntersection } from './helpers';
 import type { FindSelected } from './FindSelected';
 
@@ -116,7 +116,7 @@ export type EmptyMatch<i, o> = Match<i, o> & {
    * that **all cases are handled**. `when` predicates
    * aren't supported on exhaustive matches.
    **/
-  exhaustive: () => ExhaustiveMatch<DistributeUnions<i>, i, o>;
+  exhaustive: () => ExhaustiveMatch<i, i, o>;
 };
 
 type NonExhaustivePattern<i> = { __nonExhaustive: never } & i;
@@ -142,7 +142,7 @@ export type ExhaustiveMatch<distributedInput, i, o> = {
     // the distributedInput to ExhaustiveMatch, so we can compute the pattern
     // from the original input, which is much faster than computing it
     // from the distributed one.
-    Exclude<distributedInput, ExtractPreciseValue<i, InvertPattern<p>>>,
+    DeepExclude<distributedInput, InvertPattern<p>>,
     i,
     PickReturnValue<o, c>
   >;

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -6,10 +6,9 @@ import type { UnionToIntersection } from './helpers';
 import type { FindSelected } from './FindSelected';
 
 // We fall back to `a` if we weren't able to extract anything more precise
-export type MatchedValue<a, p extends Pattern<a>> = ExtractPreciseValue<
-  a,
-  InvertPattern<p>
-> extends never
+export type MatchedValue<a, p extends Pattern<a>> = [
+  ExtractPreciseValue<a, InvertPattern<p>>
+] extends [never]
   ? a
   : ExtractPreciseValue<a, InvertPattern<p>>;
 

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -32,7 +32,7 @@ export type Match<i, o> = {
     p extends Pattern<i>,
     c,
     invpattern = InvertPattern<p>,
-    value = p extends typeof __ ? i : MatchedValue<i, invpattern>
+    value = MatchedValue<i, invpattern>
   >(
     pattern: p,
     handler: (
@@ -137,7 +137,7 @@ export type ExhaustiveMatch<distributedInput, i, o> = {
     p extends ExhaustivePattern<i>,
     c,
     invpattern = InvertPattern<p>,
-    value = p extends typeof __ ? i : MatchedValue<i, invpattern>
+    value = MatchedValue<i, invpattern>
   >(
     pattern: p,
     handler: (

--- a/src/types/Pattern.ts
+++ b/src/types/Pattern.ts
@@ -23,19 +23,30 @@ export type GuardFunction<a, b extends a> =
   | ((value: a) => value is b)
   | ((value: a) => boolean);
 
+/**
+ * Using @deprecated here to dissuade people from using them inside there patterns.
+ * Theses properties should be used by ts-pattern's internals only.
+ */
+
 export type GuardPattern<a, b extends a = a> = {
-  __patternKind: PatternType.Guard;
-  __when: GuardFunction<a, b>;
+  /** @deprecated This property should only be used by ts-pattern's internals. */
+  '@ts-pattern/__patternKind': PatternType.Guard;
+  /** @deprecated This property should only be used by ts-pattern's internals. */
+  '@ts-pattern/__when': GuardFunction<a, b>;
 };
 
 export type NotPattern<a> = {
-  __patternKind: PatternType.Not;
-  __pattern: Pattern<a>;
+  /** @deprecated This property should only be used by ts-pattern's internals. */
+  '@ts-pattern/__patternKind': PatternType.Not;
+  /** @deprecated This property should only be used by ts-pattern's internals. */
+  '@ts-pattern/__pattern': Pattern<a>;
 };
 
 export type SelectPattern<k extends string> = {
-  __patternKind: PatternType.Select;
-  __key: k;
+  /** @deprecated This property should only be used by ts-pattern's internals. */
+  '@ts-pattern/__patternKind': PatternType.Select;
+  /** @deprecated This property should only be used by ts-pattern's internals. */
+  '@ts-pattern/__key': k;
 };
 
 type WildCardPattern<a> = a extends number

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -149,3 +149,14 @@ export type IsPlainObject<o> = o extends object
 export type Compute<a extends any> = a extends BuiltInObjects
   ? a
   : { [k in keyof a]: a[k] } & unknown;
+
+export type UnionLength<a> = Length<UnionToTuple<a>>;
+
+// All :: Bool[] -> Bool
+export type All<xs> = xs extends [infer head, ...(infer tail)]
+  ? boolean extends head
+    ? false
+    : head extends true
+    ? All<tail>
+    : false
+  : true;

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -47,40 +47,7 @@ export type UnionToIntersection<U> = (
   ? I
   : never;
 
-type IsLiteralString<T extends string> = string extends T ? false : true;
-type IsLiteralNumber<T extends number> = number extends T ? false : true;
-type IsLiteralBoolean<T extends boolean> = boolean extends T ? false : true;
-export type IsLiteral<T> = T extends string
-  ? IsLiteralString<T>
-  : T extends number
-  ? IsLiteralNumber<T>
-  : T extends boolean
-  ? IsLiteralBoolean<T>
-  : false;
-
 export type IsUnion<a> = [a] extends [UnionToIntersection<a>] ? false : true;
-
-export type ContainsUnion<a> = IsUnion<a> extends true
-  ? true
-  : IsPlainObject<a> extends true
-  ? false extends ValueOf<{ [k in keyof a]: ContainsUnion<a[k]> }>
-    ? false
-    : true
-  : false;
-
-type NeverKeys<o> = ValueOf<
-  {
-    [k in keyof o]: [o[k]] extends [never] ? k : never;
-  }
->;
-
-type RemoveNeverKeys<o> = Omit<o, NeverKeys<o>>;
-
-export type ExcludeUnion<a> = IsUnion<a> extends true
-  ? never
-  : IsPlainObject<a> extends true
-  ? RemoveNeverKeys<{ [k in keyof a]: ExcludeUnion<a[k]> }>
-  : a;
 
 export type UnionToTuple<T> = UnionToIntersection<
   T extends any ? (t: T) => T : never
@@ -149,8 +116,6 @@ export type IsPlainObject<o> = o extends object
 export type Compute<a extends any> = a extends BuiltInObjects
   ? a
   : { [k in keyof a]: a[k] } & unknown;
-
-export type UnionLength<a> = Length<UnionToTuple<a>>;
 
 // All :: Bool[] -> Bool
 export type All<xs> = xs extends [infer head, ...(infer tail)]

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -160,3 +160,5 @@ export type All<xs> = xs extends [infer head, ...(infer tail)]
     ? All<tail>
     : false
   : true;
+
+export type WithDefault<a, def> = [a] extends [never] ? def : a;

--- a/tests/deep-exclude.test.ts
+++ b/tests/deep-exclude.test.ts
@@ -9,7 +9,7 @@ describe('DeepExclude', () => {
   /**
    * TODO
    * all types:
-   * - data list, set, maps
+   * - data   set, maps
    * - mixed nested data structures
    *
    * case * (matching everything, matching something, matching nothing)
@@ -59,10 +59,7 @@ describe('DeepExclude', () => {
           Equal<DeepExclude<{ a: 'x' | 'y' }, { b: 'x' }>, { a: 'x' | 'y' }>
         >,
         Expect<
-          Equal<
-            DeepExclude<{ a: 'x' | 'y' }, { a: 'z' }>,
-            { a: 'x' } | { a: 'y' }
-          >
+          Equal<DeepExclude<{ a: 'x' | 'y' }, { a: 'z' }>, { a: 'x' | 'y' }>
         >
       ];
     });
@@ -122,7 +119,7 @@ describe('DeepExclude', () => {
 
     it("if it doesn't match, it should leave the data structure untouched", () => {
       type cases = [
-        Expect<Equal<DeepExclude<['x' | 'y'], ['z']>, ['x'] | ['y']>>,
+        Expect<Equal<DeepExclude<['x' | 'y'], ['z']>, ['x' | 'y']>>,
         Expect<Equal<DeepExclude<['x' | 'y'], []>, ['x' | 'y']>>,
         Expect<Equal<DeepExclude<['x' | 'y'], ['a', 'b', 'c']>, ['x' | 'y']>>
       ];
@@ -144,6 +141,41 @@ describe('DeepExclude', () => {
           Equal<
             DeepExclude<[['x' | 'y' | 'z'], 'u' | 'v'], [unknown, 'v']>,
             [['x' | 'y' | 'z'], 'u']
+          >
+        >
+      ];
+    });
+  });
+
+  describe('List', () => {
+    type cases = [
+      Expect<Equal<DeepExclude<(1 | 2 | 3)[], 1[]>, (1 | 2 | 3)[]>>,
+      Expect<Equal<DeepExclude<(1 | 2 | 3)[], (1 | 2 | 3)[]>, never>>,
+      Expect<Equal<DeepExclude<(1 | 2 | 3)[], unknown[]>, never>>,
+      Expect<
+        Equal<DeepExclude<(1 | 2 | 3)[] | string[], string[]>, (1 | 2 | 3)[]>
+      >
+    ];
+
+    it('should work with empty list patterns', () => {
+      type cases = [
+        Expect<Equal<DeepExclude<[] | [1, 2, 3], []>, [1, 2, 3]>>,
+        Expect<
+          Equal<
+            DeepExclude<{ values: [] | [1, 2, 3] }, { values: [] }>,
+            { values: [1, 2, 3] }
+          >
+        >,
+        Expect<
+          Equal<
+            DeepExclude<{ values: [1, 2, 3] }, { values: [] }>,
+            { values: [1, 2, 3] }
+          >
+        >,
+        Expect<
+          Equal<
+            DeepExclude<{ values: (1 | 2 | 3)[] }, { values: [] }>,
+            { values: (1 | 2 | 3)[] }
           >
         >
       ];
@@ -190,30 +222,6 @@ describe('DeepExclude', () => {
               union: 'a';
               union2: BigUnion;
             }
-        >
-      >
-    ];
-  });
-
-  it('should work with empty list patterns', () => {
-    type cases = [
-      Expect<Equal<DeepExclude<[] | [1, 2, 3], []>, [1, 2, 3]>>,
-      Expect<
-        Equal<
-          DeepExclude<{ values: [] | [1, 2, 3] }, { values: [] }>,
-          { values: [1, 2, 3] }
-        >
-      >,
-      Expect<
-        Equal<
-          DeepExclude<{ values: [1, 2, 3] }, { values: [] }>,
-          { values: [1, 2, 3] }
-        >
-      >,
-      Expect<
-        Equal<
-          DeepExclude<{ values: (1 | 2 | 3)[] }, { values: [] }>,
-          { values: (1 | 2 | 3)[] }
         >
       >
     ];

--- a/tests/deep-exclude.test.ts
+++ b/tests/deep-exclude.test.ts
@@ -1,10 +1,155 @@
 import { DeepExclude } from '../src/types/DeepExclude';
 import { Equal, Expect } from '../src/types/helpers';
+import { Primitives } from '../src/types/Pattern';
 import { BigUnion, Option } from './utils';
 
 type Colors = 'pink' | 'purple' | 'red' | 'yellow' | 'blue';
 
 describe('DeepExclude', () => {
+  /**
+   * TODO
+   * all types:
+   * - data list, set, maps
+   * - mixed nested data structures
+   *
+   * case * (matching everything, matching something, matching nothing)
+   */
+
+  it('Primitives', () => {
+    type cases = [
+      Expect<Equal<DeepExclude<string, 'hello'>, string>>,
+      Expect<Equal<DeepExclude<string, string>, never>>,
+      Expect<Equal<DeepExclude<string | number, string>, number>>,
+      Expect<Equal<DeepExclude<string | number, boolean>, string | number>>,
+      Expect<
+        Equal<
+          DeepExclude<Primitives, null | undefined>,
+          string | number | bigint | boolean | symbol
+        >
+      >,
+      Expect<Equal<DeepExclude<Primitives, never>, Primitives>>
+    ];
+  });
+
+  it('Literals', () => {
+    type cases = [
+      Expect<Equal<DeepExclude<'hello' | 'bonjour', 'hello'>, 'bonjour'>>,
+      Expect<
+        Equal<DeepExclude<'hello' | 'bonjour', 'hola'>, 'hello' | 'bonjour'>
+      >,
+      Expect<Equal<DeepExclude<1 | 2 | 3, 3>, 1 | 2>>,
+      Expect<Equal<DeepExclude<'hello' | 1, string>, 1>>,
+      Expect<Equal<DeepExclude<'hello' | 1, number>, 'hello'>>,
+      Expect<Equal<DeepExclude<200n | number, bigint>, number>>,
+      Expect<Equal<DeepExclude<undefined | number, number>, undefined>>
+    ];
+  });
+
+  describe('Objects', () => {
+    it('should correctly exclude when it matches', () => {
+      type cases = [
+        Expect<Equal<DeepExclude<{ a: 'x' | 'y' }, { a: string }>, never>>,
+        Expect<Equal<DeepExclude<{ a: 'x' | 'y' }, { a: 'x' }>, { a: 'y' }>>
+      ];
+    });
+
+    it("if it doesn't match, it should leave the data structure untouched", () => {
+      type cases = [
+        Expect<
+          Equal<DeepExclude<{ a: 'x' | 'y' }, { b: 'x' }>, { a: 'x' | 'y' }>
+        >,
+        Expect<
+          Equal<
+            DeepExclude<{ a: 'x' | 'y' }, { a: 'z' }>,
+            { a: 'x' } | { a: 'y' }
+          >
+        >
+      ];
+    });
+
+    it('should work with nested object and only distribute what is necessary', () => {
+      type cases = [
+        Expect<
+          Equal<
+            DeepExclude<{ a: { b: 'x' | 'y' } }, { a: { b: 'x' } }>,
+            { a: { b: 'y' } }
+          >
+        >,
+        Expect<
+          Equal<
+            DeepExclude<{ a: { b: 'x' | 'y' | 'z' } }, { a: { b: 'x' } }>,
+            { a: { b: 'y' } } | { a: { b: 'z' } }
+          >
+        >,
+        Expect<
+          Equal<
+            DeepExclude<
+              { a: { b: 'x' | 'y' | 'z' }; c: 'u' | 'v' },
+              { a: { b: 'x' } }
+            >,
+            { a: { b: 'y' }; c: 'u' | 'v' } | { a: { b: 'z' }; c: 'u' | 'v' }
+          >
+        >,
+        Expect<
+          Equal<
+            DeepExclude<
+              { a: { b: 'x' | 'y' | 'z' }; c: 'u' | 'v' },
+              { c: 'u' }
+            >,
+            { a: { b: 'x' | 'y' | 'z' }; c: 'v' }
+          >
+        >,
+        Expect<
+          Equal<
+            DeepExclude<
+              { a: { b: 'x' | 'y' | 'z' }; c: 'u' | 'v' },
+              { c: 'u' }
+            >,
+            { a: { b: 'x' | 'y' | 'z' }; c: 'v' }
+          >
+        >
+      ];
+    });
+  });
+
+  describe('Tuples', () => {
+    it('should correctly exclude when it matches', () => {
+      type cases = [
+        Expect<Equal<DeepExclude<['x' | 'y'], [string]>, never>>,
+        Expect<Equal<DeepExclude<['x' | 'y'], ['x']>, ['y']>>
+      ];
+    });
+
+    it("if it doesn't match, it should leave the data structure untouched", () => {
+      type cases = [
+        Expect<Equal<DeepExclude<['x' | 'y'], ['z']>, ['x'] | ['y']>>,
+        Expect<Equal<DeepExclude<['x' | 'y'], []>, ['x' | 'y']>>,
+        Expect<Equal<DeepExclude<['x' | 'y'], ['a', 'b', 'c']>, ['x' | 'y']>>
+      ];
+    });
+
+    it('should work with nested tuples and only distribute what is necessary', () => {
+      type cases = [
+        Expect<Equal<DeepExclude<[['x' | 'y']], [['x']]>, [['y']]>>,
+        Expect<
+          Equal<DeepExclude<[['x' | 'y' | 'z']], [['x']]>, [['y']] | [['z']]>
+        >,
+        Expect<
+          Equal<
+            DeepExclude<[['x' | 'y' | 'z'], 'u' | 'v'], [['x'], unknown]>,
+            [['y'], 'u' | 'v'] | [['z'], 'u' | 'v']
+          >
+        >,
+        Expect<
+          Equal<
+            DeepExclude<[['x' | 'y' | 'z'], 'u' | 'v'], [unknown, 'v']>,
+            [['x' | 'y' | 'z'], 'u']
+          >
+        >
+      ];
+    });
+  });
+
   it('should work with bug unions', () => {
     type cases = [
       Expect<

--- a/tests/deep-exclude.test.ts
+++ b/tests/deep-exclude.test.ts
@@ -6,50 +6,48 @@ type Colors = 'pink' | 'purple' | 'red' | 'yellow' | 'blue';
 
 describe('DeepExclude', () => {
   it('should work with bug unions', () => {
-    it('should work with big unions', () => {
-      type cases = [
-        Expect<
-          Equal<
-            DeepExclude<
-              | { type: 'textWithColor'; union: BigUnion }
-              | {
-                  type: 'textWithColorAndBackground';
-                  union: BigUnion;
-                  union2: BigUnion;
-                },
-              { type: 'textWithColor' }
-            >,
-            {
-              type: 'textWithColorAndBackground';
-              union: BigUnion;
-              union2: BigUnion;
-            }
-          >
-        >,
-        Expect<
-          Equal<
-            DeepExclude<
-              | { type: 'textWithColor'; union: BigUnion }
-              | {
-                  type: 'textWithColorAndBackground';
-                  union: BigUnion;
-                  union2: BigUnion;
-                },
-              {
-                type: 'textWithColorAndBackground';
-                union: Exclude<BigUnion, 'a'>;
-              }
-            >,
+    type cases = [
+      Expect<
+        Equal<
+          DeepExclude<
             | { type: 'textWithColor'; union: BigUnion }
             | {
                 type: 'textWithColorAndBackground';
-                union: 'a';
+                union: BigUnion;
                 union2: BigUnion;
-              }
-          >
+              },
+            { type: 'textWithColor' }
+          >,
+          {
+            type: 'textWithColorAndBackground';
+            union: BigUnion;
+            union2: BigUnion;
+          }
         >
-      ];
-    });
+      >,
+      Expect<
+        Equal<
+          DeepExclude<
+            | { type: 'textWithColor'; union: BigUnion }
+            | {
+                type: 'textWithColorAndBackground';
+                union: BigUnion;
+                union2: BigUnion;
+              },
+            {
+              type: 'textWithColorAndBackground';
+              union: Exclude<BigUnion, 'a'>;
+            }
+          >,
+          | { type: 'textWithColor'; union: BigUnion }
+          | {
+              type: 'textWithColorAndBackground';
+              union: 'a';
+              union2: BigUnion;
+            }
+        >
+      >
+    ];
   });
 
   it('should work with empty list patterns', () => {

--- a/tests/deep-exclude.test.ts
+++ b/tests/deep-exclude.test.ts
@@ -53,6 +53,24 @@ describe('DeepExclude', () => {
     });
   });
 
+  it('should work with empty list patterns', () => {
+    type cases = [
+      Expect<Equal<DeepExclude<[] | [1, 2, 3], []>, [1, 2, 3]>>,
+      Expect<
+        Equal<
+          DeepExclude<{ values: [] | [1, 2, 3] }, { values: [] }>,
+          { values: [1, 2, 3] }
+        >
+      >,
+      Expect<
+        Equal<
+          DeepExclude<{ values: [1, 2, 3] }, { values: [] }>,
+          { values: [1, 2, 3] }
+        >
+      >
+    ];
+  });
+
   it('should work in common cases', () => {});
   type cases = [
     Expect<Equal<DeepExclude<'a' | 'b' | 'c', 'a'>, 'b' | 'c'>>,

--- a/tests/deep-exclude.test.ts
+++ b/tests/deep-exclude.test.ts
@@ -1,0 +1,134 @@
+import { DeepExclude } from '../src/types/DeepExclude';
+import { Equal, Expect } from '../src/types/helpers';
+import { NotPattern } from '../src/types/Pattern';
+import { BigUnion, Option } from './utils';
+
+type Colors = 'pink' | 'purple' | 'red' | 'yellow' | 'blue';
+
+describe('DeepExclude', () => {
+  it('should work with bug unions', () => {
+    it('should work with big unions', () => {
+      type x = DeepExclude<
+        | { type: 'textWithColor'; union: BigUnion }
+        | {
+            type: 'textWithColorAndBackground';
+            union: BigUnion;
+            union2: BigUnion;
+          },
+        {
+          type: 'textWithColorAndBackground';
+          union: NotPattern<'a'>;
+        }
+      >;
+
+      type cases = [
+        Expect<
+          Equal<
+            DeepExclude<
+              | { type: 'textWithColor'; union: BigUnion }
+              | {
+                  type: 'textWithColorAndBackground';
+                  union: BigUnion;
+                  union2: BigUnion;
+                },
+              { type: 'textWithColor' }
+            >,
+            {
+              type: 'textWithColorAndBackground';
+              union: BigUnion;
+              union2: BigUnion;
+            }
+          >
+        >,
+        Expect<
+          // TODO : fix this case
+          Equal<
+            DeepExclude<
+              | { type: 'textWithColor'; union: BigUnion }
+              | {
+                  type: 'textWithColorAndBackground';
+                  union: BigUnion;
+                  union2: BigUnion;
+                },
+              {
+                type: 'textWithColorAndBackground';
+                union: NotPattern<'a'>;
+              }
+            >,
+            | { type: 'textWithColor'; union: BigUnion }
+            | {
+                type: 'textWithColorAndBackground';
+                union: 'a';
+              }
+          >
+        >
+      ];
+    });
+  });
+
+  it('should work in common cases', () => {});
+  type cases = [
+    Expect<Equal<DeepExclude<'a' | 'b' | 'c', 'a'>, 'b' | 'c'>>,
+    Expect<
+      Equal<
+        DeepExclude<
+          | { type: 'textWithColor'; color: Colors }
+          | {
+              type: 'textWithColorAndBackground';
+              color: Colors;
+              backgroundColor: Colors;
+            },
+          { type: 'textWithColor' }
+        >,
+        {
+          type: 'textWithColorAndBackground';
+          color: Colors;
+          backgroundColor: Colors;
+        }
+      >
+    >,
+    Expect<
+      Equal<
+        DeepExclude<
+          | { type: 'textWithColor'; color: Colors }
+          | {
+              type: 'textWithColorAndBackground';
+              color: Colors;
+              backgroundColor: Colors;
+            },
+          { type: 'textWithColor'; color: 'pink' }
+        >,
+        | {
+            type: 'textWithColorAndBackground';
+            color: Colors;
+            backgroundColor: Colors;
+          }
+        | { type: 'textWithColor'; color: 'purple' }
+        | { type: 'textWithColor'; color: 'red' }
+        | { type: 'textWithColor'; color: 'yellow' }
+        | { type: 'textWithColor'; color: 'blue' }
+      >
+    >,
+    Expect<
+      Equal<
+        DeepExclude<
+          [Option<{ type: 'a' } | { type: 'b' }>, 'c' | 'd'],
+          [{ kind: 'some'; value: { type: 'a' } }, any]
+        >,
+        | [{ kind: 'none' }, 'c' | 'd']
+        | [{ kind: 'some'; value: { type: 'b' } }, 'c' | 'd']
+      >
+    >,
+    Expect<
+      Equal<
+        DeepExclude<
+          { x: 'a' | 'b'; y: 'c' | 'd'; z: 'e' | 'f' },
+          { x: 'a'; y: 'c' }
+        >,
+        | { x: 'b'; y: 'c'; z: 'e' | 'f' }
+        | { x: 'b'; y: 'd'; z: 'e' | 'f' }
+        | { x: 'a'; y: 'd'; z: 'e' | 'f' }
+      >
+    >
+  ];
+});

--- a/tests/deep-exclude.test.ts
+++ b/tests/deep-exclude.test.ts
@@ -8,19 +8,6 @@ type Colors = 'pink' | 'purple' | 'red' | 'yellow' | 'blue';
 describe('DeepExclude', () => {
   it('should work with bug unions', () => {
     it('should work with big unions', () => {
-      type x = DeepExclude<
-        | { type: 'textWithColor'; union: BigUnion }
-        | {
-            type: 'textWithColorAndBackground';
-            union: BigUnion;
-            union2: BigUnion;
-          },
-        {
-          type: 'textWithColorAndBackground';
-          union: NotPattern<'a'>;
-        }
-      >;
-
       type cases = [
         Expect<
           Equal<
@@ -41,7 +28,6 @@ describe('DeepExclude', () => {
           >
         >,
         Expect<
-          // TODO : fix this case
           Equal<
             DeepExclude<
               | { type: 'textWithColor'; union: BigUnion }
@@ -59,6 +45,7 @@ describe('DeepExclude', () => {
             | {
                 type: 'textWithColorAndBackground';
                 union: 'a';
+                union2: BigUnion;
               }
           >
         >

--- a/tests/deep-exclude.test.ts
+++ b/tests/deep-exclude.test.ts
@@ -38,7 +38,7 @@ describe('DeepExclude', () => {
                 },
               {
                 type: 'textWithColorAndBackground';
-                union: NotPattern<'a'>;
+                union: Exclude<BigUnion, 'a'>;
               }
             >,
             | { type: 'textWithColor'; union: BigUnion }

--- a/tests/deep-exclude.test.ts
+++ b/tests/deep-exclude.test.ts
@@ -1,6 +1,5 @@
 import { DeepExclude } from '../src/types/DeepExclude';
 import { Equal, Expect } from '../src/types/helpers';
-import { NotPattern } from '../src/types/Pattern';
 import { BigUnion, Option } from './utils';
 
 type Colors = 'pink' | 'purple' | 'red' | 'yellow' | 'blue';
@@ -66,6 +65,12 @@ describe('DeepExclude', () => {
         Equal<
           DeepExclude<{ values: [1, 2, 3] }, { values: [] }>,
           { values: [1, 2, 3] }
+        >
+      >,
+      Expect<
+        Equal<
+          DeepExclude<{ values: (1 | 2 | 3)[] }, { values: [] }>,
+          { values: (1 | 2 | 3)[] }
         >
       >
     ];

--- a/tests/deep-exclude.test.ts
+++ b/tests/deep-exclude.test.ts
@@ -6,15 +6,6 @@ import { BigUnion, Option } from './utils';
 type Colors = 'pink' | 'purple' | 'red' | 'yellow' | 'blue';
 
 describe('DeepExclude', () => {
-  /**
-   * TODO
-   * all types:
-   * - data   set, maps
-   * - mixed nested data structures
-   *
-   * case * (matching everything, matching something, matching nothing)
-   */
-
   it('Primitives', () => {
     type cases = [
       Expect<Equal<DeepExclude<string, 'hello'>, string>>,
@@ -180,6 +171,49 @@ describe('DeepExclude', () => {
         >
       ];
     });
+  });
+
+  describe('Sets', () => {
+    type cases = [
+      Expect<Equal<DeepExclude<Set<1 | 2 | 3>, Set<1>>, Set<1 | 2 | 3>>>,
+      Expect<Equal<DeepExclude<Set<1 | 2 | 3>, Set<1 | 2 | 3>>, never>>,
+      Expect<Equal<DeepExclude<Set<1 | 2 | 3>, Set<unknown>>, never>>,
+      Expect<
+        Equal<
+          DeepExclude<Set<1 | 2 | 3> | Set<string>, Set<string>>,
+          Set<1 | 2 | 3>
+        >
+      >
+    ];
+  });
+
+  describe('Maps', () => {
+    type cases = [
+      Expect<
+        Equal<
+          DeepExclude<Map<string, 1 | 2 | 3>, Map<string, 1>>,
+          Map<string, 1 | 2 | 3>
+        >
+      >,
+      Expect<
+        Equal<
+          DeepExclude<Map<string, 1 | 2 | 3>, Map<string, 1 | 2 | 3>>,
+          never
+        >
+      >,
+      Expect<
+        Equal<DeepExclude<Map<string, 1 | 2 | 3>, Map<string, unknown>>, never>
+      >,
+      Expect<
+        Equal<
+          DeepExclude<
+            Map<string, 1 | 2 | 3> | Map<string, string>,
+            Map<string, string>
+          >,
+          Map<string, 1 | 2 | 3>
+        >
+      >
+    ];
   });
 
   it('should work with bug unions', () => {

--- a/tests/distribute-unions.test.ts
+++ b/tests/distribute-unions.test.ts
@@ -631,19 +631,34 @@ describe('DistributeMatchingUnions', () => {
   });
 
   it('should work with objects', () => {
-    type obj = {
-      type: 'type';
-      x: undefined;
-      q: string;
-      union1: 'a' | 'b';
-      color: '3';
-      union2: '1' | '2';
-    };
+    type X = 1 | 2 | 3 | 4 | 5 | 6 | 7;
 
     type cases = [
       Expect<
         Equal<
-          DistributeUnions<obj>,
+          DistributeMatchingUnions<
+            { a: X; b: X; c: X; d: X; e: X; f: X; g: X; h: X; i: X },
+            { a: 1 }
+          >,
+          | { a: 1; b: X; c: X; d: X; e: X; f: X; g: X; h: X; i: X }
+          | { a: 2; b: X; c: X; d: X; e: X; f: X; g: X; h: X; i: X }
+          | { a: 3; b: X; c: X; d: X; e: X; f: X; g: X; h: X; i: X }
+          | { a: 4; b: X; c: X; d: X; e: X; f: X; g: X; h: X; i: X }
+          | { a: 5; b: X; c: X; d: X; e: X; f: X; g: X; h: X; i: X }
+          | { a: 6; b: X; c: X; d: X; e: X; f: X; g: X; h: X; i: X }
+          | { a: 7; b: X; c: X; d: X; e: X; f: X; g: X; h: X; i: X }
+        >
+      >,
+      Expect<
+        Equal<
+          DistributeUnions<{
+            type: 'type';
+            x: undefined;
+            q: string;
+            union1: 'a' | 'b';
+            color: '3';
+            union2: '1' | '2';
+          }>,
           | {
               type: 'type';
               q: string;

--- a/tests/distribute-unions.test.ts
+++ b/tests/distribute-unions.test.ts
@@ -1,5 +1,5 @@
 import {
-  FindUnions,
+  FindAllUnions,
   Distribute,
   DistributeUnions,
 } from '../src/types/DistributeUnions';
@@ -7,12 +7,12 @@ import {
 import { Equal, Expect } from '../src/types/helpers';
 import { Option } from './utils';
 
-describe('FindUnions', () => {
+describe('FindAllUnions', () => {
   it('should correctly find all unions on an object', () => {
     type cases = [
       Expect<
         Equal<
-          FindUnions<{ a: 1 | 2; b: 3 | 4 }>,
+          FindAllUnions<{ a: 1 | 2; b: 3 | 4 }>,
           [
             {
               cases:
@@ -43,7 +43,7 @@ describe('FindUnions', () => {
       >,
       Expect<
         Equal<
-          FindUnions<{ a: 1 | 2; b: 3 | 4; c: 5 | 6 }>,
+          FindAllUnions<{ a: 1 | 2; b: 3 | 4; c: 5 | 6 }>,
           [
             {
               cases:
@@ -86,7 +86,7 @@ describe('FindUnions', () => {
       >,
       Expect<
         Equal<
-          FindUnions<{
+          FindAllUnions<{
             a: 1 | 2;
             b: 3 | 4;
             c: 5 | 6;
@@ -158,7 +158,7 @@ describe('FindUnions', () => {
       >,
       Expect<
         Equal<
-          FindUnions<{
+          FindAllUnions<{
             a: {
               b: {
                 e: 7 | 8;
@@ -196,7 +196,7 @@ describe('FindUnions', () => {
       >,
       Expect<
         Equal<
-          FindUnions<{
+          FindAllUnions<{
             e: 'not a union';
             a: {
               e: 7 | 8;
@@ -251,7 +251,7 @@ describe('FindUnions', () => {
     type cases = [
       Expect<
         Equal<
-          FindUnions<[1 | 2, 3 | 4]>,
+          FindAllUnions<[1 | 2, 3 | 4]>,
           [
             {
               cases:
@@ -282,7 +282,7 @@ describe('FindUnions', () => {
       >,
       Expect<
         Equal<
-          FindUnions<[1 | 2, 3 | 4, 5 | 6]>,
+          FindAllUnions<[1 | 2, 3 | 4, 5 | 6]>,
           [
             {
               cases:
@@ -325,7 +325,9 @@ describe('FindUnions', () => {
       >,
       Expect<
         Equal<
-          FindUnions<{ type: 'a'; value: 1 | 2 } | { type: 'b'; value: 4 | 5 }>,
+          FindAllUnions<
+            { type: 'a'; value: 1 | 2 } | { type: 'b'; value: 4 | 5 }
+          >,
           [
             {
               cases:
@@ -523,6 +525,8 @@ describe('Distribute', () => {
 });
 
 describe('DistributeUnions', () => {
+  type x = DistributeUnions<{ a: 1 | 2; b: '3' | '4'; c: '5' | '6' }>;
+
   type cases = [
     Expect<
       Equal<
@@ -576,8 +580,8 @@ describe('DistributeUnions', () => {
           | ['two', { kind: 'none' }]
           | ['two', { kind: 'some'; value: string }]
           | [3, { kind: 'none' }]
-          | [3, { kind: 'some'; value: false }]
           | [3, { kind: 'some'; value: true }]
+          | [3, { kind: 'some'; value: false }]
         >
       >
     ];

--- a/tests/distribute-unions.test.ts
+++ b/tests/distribute-unions.test.ts
@@ -618,8 +618,6 @@ describe('DistributeMatchingUnions', () => {
         >
       >
     ];
-
-    type x = DistributeMatchingUnions<['a' | 'b', 1 | 2], ['a', unknown]>;
   });
 
   it("unknown should match but shouldn't distribute", () => {

--- a/tests/distribute-unions.test.ts
+++ b/tests/distribute-unions.test.ts
@@ -622,6 +622,54 @@ describe('DistributeMatchingUnions', () => {
     type x = DistributeMatchingUnions<['a' | 'b', 1 | 2], ['a', unknown]>;
   });
 
+  it("unknown should match but shouldn't distribute", () => {
+    type cases = [
+      Expect<
+        Equal<
+          DistributeMatchingUnions<
+            [1, ['two', Option<string>]] | [3, Option<boolean>],
+            [1, unknown]
+          >,
+          [1, ['two', Option<string>]] | [3, Option<boolean>]
+        >
+      >,
+      Expect<
+        Equal<
+          DistributeMatchingUnions<
+            { a: 1 | 2; b: '3' | '4'; c: '5' | '6' },
+            { a: 1; b: unknown; c: unknown }
+          >,
+          | { a: 1; b: '3' | '4'; c: '5' | '6' }
+          | { a: 2; b: '3' | '4'; c: '5' | '6' }
+        >
+      >,
+      Expect<
+        Equal<
+          DistributeMatchingUnions<
+            { a: 1 | 2; b: '3' | '4'; c: '5' | '6' },
+            { a: 1; b: '3'; c: unknown }
+          >,
+          | { a: 1; b: '3'; c: '5' | '6' }
+          | { a: 2; b: '3'; c: '5' | '6' }
+          | { a: 1; b: '4'; c: '5' | '6' }
+          | { a: 2; b: '4'; c: '5' | '6' }
+        >
+      >,
+      Expect<
+        Equal<
+          DistributeMatchingUnions<
+            { a: 1 | 2; b: ['3' | '4', '5' | '6'] },
+            { a: 1; b: ['3', unknown] }
+          >,
+          | { a: 1; b: ['3', '5' | '6'] }
+          | { a: 2; b: ['3', '5' | '6'] }
+          | { a: 1; b: ['4', '5' | '6'] }
+          | { a: 2; b: ['4', '5' | '6'] }
+        >
+      >
+    ];
+  });
+
   it('should work for non unions', () => {
     type cases = [
       Expect<Equal<DistributeMatchingUnions<{}, {}>, {}>>,

--- a/tests/exhaustive-match.test.ts
+++ b/tests/exhaustive-match.test.ts
@@ -1,8 +1,4 @@
 import { match, not, when, __ } from '../src';
-import { DeepExclude } from '../src/types/DeepExclude';
-import { DistributeMatchingUnions } from '../src/types/DistributeUnions';
-import { InvertNotPattern } from '../src/types/InvertPattern';
-import { NotPattern } from '../src/types/Pattern';
 import { Option, some, none, BigUnion } from './utils';
 
 describe('exhaustive()', () => {
@@ -534,11 +530,11 @@ describe('exhaustive()', () => {
         .exhaustive()
         .with({ a: 'a' }, () => 0)
         .with({ a: 'b' }, () => 0)
-        .with({ a: 'c' }, () => 0)
+        .with({ a: 'c' }, (x) => 0)
         .with({ a: 'd' }, () => 0)
-        .with({ a: 'e' }, () => 0)
-        .with({ a: 'f', b: __ }, () => 0)
-        .with({ a: __ }, () => 0)
+        .with({ a: 'e' }, (x) => 0)
+        .with({ a: 'f', b: __ }, (x) => 0)
+        .with({ a: __ }, (x) => 0)
         .run();
     });
 

--- a/tests/exhaustive-match.test.ts
+++ b/tests/exhaustive-match.test.ts
@@ -1,4 +1,8 @@
-import { match, when, __ } from '../src';
+import { match, not, when, __ } from '../src';
+import { DeepExclude } from '../src/types/DeepExclude';
+import { DistributeMatchingUnions } from '../src/types/DistributeUnions';
+import { InvertNotPattern } from '../src/types/InvertPattern';
+import { NotPattern } from '../src/types/Pattern';
 import { Option, some, none } from './utils';
 
 describe('exhaustive()', () => {
@@ -507,6 +511,16 @@ describe('exhaustive()', () => {
         .with({ b: 5 }, () => 'otherwise')
         .with({ b: 6 }, () => 'otherwise')
         .with({ b: 7 }, () => 'otherwise')
+        .run();
+
+      match<{
+        a: X;
+        b: X;
+        c: X;
+      }>({ a: 1, b: 1, c: 1 })
+        .exhaustive()
+        .with({ a: not(1) }, () => 'a != 1')
+        .with({ a: 1 }, () => 'a != 1')
         .run();
     });
 

--- a/tests/exhaustive-match.test.ts
+++ b/tests/exhaustive-match.test.ts
@@ -3,7 +3,7 @@ import { DeepExclude } from '../src/types/DeepExclude';
 import { DistributeMatchingUnions } from '../src/types/DistributeUnions';
 import { InvertNotPattern } from '../src/types/InvertPattern';
 import { NotPattern } from '../src/types/Pattern';
-import { Option, some, none } from './utils';
+import { Option, some, none, BigUnion } from './utils';
 
 describe('exhaustive()', () => {
   it('should forbid using guard function, in pattern or as extra args', () => {
@@ -474,7 +474,7 @@ describe('exhaustive()', () => {
       expect(
         match(input)
           .exhaustive()
-          .with(new Map([['hello', 1 as const]]), (x) => x)
+          .with(new Map([['hello' as const, 1 as const]]), (x) => x)
           // @ts-expect-error
           .run()
       ).toEqual(input);
@@ -495,7 +495,7 @@ describe('exhaustive()', () => {
 
     it('should work with structures with a lot of unions', () => {
       type X = 1 | 2 | 3 | 4 | 5 | 6 | 7;
-      // This structures has 7 ** 3 = 343 possibilities
+      // This structures has 7 ** 9 = 40353607 possibilities
       match<{
         a: X;
         b: X;
@@ -508,8 +508,6 @@ describe('exhaustive()', () => {
         i: X;
       }>({ a: 1, b: 1, c: 1, d: 1, e: 1, f: 1, g: 1, h: 1, i: 1 })
         .exhaustive()
-        .with({ a: 1 }, () => 'a = 1')
-        .with({ c: 1 }, () => 'c = 1')
         .with({ b: 1 }, () => 'otherwise')
         .with({ b: 2 }, () => 'b = 2')
         .with({ b: 3 }, () => 'otherwise')
@@ -527,6 +525,20 @@ describe('exhaustive()', () => {
         .exhaustive()
         .with({ a: not(1) }, () => 'a != 1')
         .with({ a: 1 }, () => 'a != 1')
+        .run();
+
+      match<{
+        a: BigUnion;
+        b: BigUnion;
+      }>({ a: 'a', b: 'b' })
+        .exhaustive()
+        .with({ a: 'a' }, () => 0)
+        .with({ a: 'b' }, () => 0)
+        .with({ a: 'c' }, () => 0)
+        .with({ a: 'd' }, () => 0)
+        .with({ a: 'e' }, () => 0)
+        .with({ a: 'f', b: __ }, () => 0)
+        .with({ a: __ }, () => 0)
         .run();
     });
 

--- a/tests/exhaustive-match.test.ts
+++ b/tests/exhaustive-match.test.ts
@@ -500,7 +500,13 @@ describe('exhaustive()', () => {
         a: X;
         b: X;
         c: X;
-      }>({ a: 1, b: 1, c: 1 })
+        d: X;
+        e: X;
+        f: X;
+        g: X;
+        h: X;
+        i: X;
+      }>({ a: 1, b: 1, c: 1, d: 1, e: 1, f: 1, g: 1, h: 1, i: 1 })
         .exhaustive()
         .with({ a: 1 }, () => 'a = 1')
         .with({ c: 1 }, () => 'c = 1')

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -1,0 +1,28 @@
+import { All, Equal, Expect } from '../src/types/helpers';
+
+describe('helpers', () => {
+  describe('All', () => {
+    it('should return true if all values are true', () => {
+      type cases = [
+        Expect<Equal<All<[]>, true>>,
+        Expect<Equal<All<[true, true]>, true>>,
+        Expect<Equal<All<[true, true, true]>, true>>
+      ];
+    });
+
+    it('should return false if some values are false', () => {
+      type cases = [
+        Expect<Equal<All<[false]>, false>>,
+        Expect<Equal<All<[true, false]>, false>>,
+        Expect<Equal<All<[true, false, true]>, false>>
+      ];
+    });
+
+    it('should return false if some values are boolean', () => {
+      type cases = [
+        Expect<Equal<All<[true, boolean, true]>, false>>,
+        Expect<Equal<All<[boolean]>, false>>
+      ];
+    });
+  });
+});

--- a/tests/is-matching.test.ts
+++ b/tests/is-matching.test.ts
@@ -67,19 +67,23 @@ describe('IsMatching', () => {
             true
           >
         >,
-        // TODO figure out why this is matching even though it shouldn't
         Expect<
           Equal<
             IsMatching<
-              | {
-                  type: 'a';
-                  value:
-                    | { type: 'c'; value: { type: 'd' } | 2 }
-                    | { type: 'e'; value: { type: 'f' } | 3 };
-                }
-              | 12,
+              {
+                type: 'a';
+                value:
+                  | { type: 'c'; value: { type: 'd' } | 2 }
+                  | { type: 'e'; value: { type: 'f' } | 3 };
+              },
               { type: 'a'; value: { type: 'c'; value: 3 } }
             >,
+            false
+          >
+        >,
+        Expect<
+          Equal<
+            IsMatching<12, { type: 'a'; value: { type: 'c'; value: 3 } }>,
             false
           >
         >,
@@ -134,6 +138,15 @@ describe('IsMatching', () => {
               { kind: 'some'; value: { type: 'a' } }
             >,
             true
+          >
+        >,
+        Expect<
+          Equal<
+            IsMatching<
+              Option<{ type: 'a' } | { type: 'b' }>,
+              { kind: 'some'; value: { type: 'c' } }
+            >,
+            false
           >
         >,
         Expect<Equal<IsMatching<'c' | 'd', unknown>, true>>,

--- a/tests/is-matching.test.ts
+++ b/tests/is-matching.test.ts
@@ -4,6 +4,24 @@ import { Option } from './utils';
 
 describe('IsMatching', () => {
   it('should return true if the pattern matches the input,  false otherwise', () => {
+    describe('Literals', () => {
+      type cases = [
+        Expect<Equal<IsMatching<'c' | 'd', 'c'>, true>>,
+        Expect<Equal<IsMatching<'c' | 'd', 'a'>, false>>,
+        Expect<Equal<IsMatching<'c' | 'd', unknown>, true>>,
+
+        Expect<Equal<IsMatching<1 | 2, 1>, true>>,
+        Expect<Equal<IsMatching<1 | 2, 3>, false>>,
+        Expect<Equal<IsMatching<1 | 2, unknown>, true>>,
+
+        Expect<Equal<IsMatching<1 | 'a', 1>, true>>,
+        Expect<Equal<IsMatching<1 | 'a', 'a'>, true>>,
+        Expect<Equal<IsMatching<1 | 'a', 2>, false>>,
+        Expect<Equal<IsMatching<1 | 'a', 'b'>, false>>,
+        Expect<Equal<IsMatching<1 | 'a', unknown>, true>>
+      ];
+    });
+
     describe('Object', () => {
       type cases = [
         Expect<
@@ -77,7 +95,7 @@ describe('IsMatching', () => {
               },
               { type: 'a'; value: { type: 'c'; value: 3 } }
             >,
-            false
+            false //  value: 3 isn't compatible with type: 'c'
           >
         >,
         Expect<
@@ -124,12 +142,7 @@ describe('IsMatching', () => {
             >,
             false
           >
-        >
-      ];
-    });
-
-    describe('Tuples', () => {
-      type cases = [
+        >,
         Expect<
           Equal<
             IsMatching<
@@ -148,7 +161,23 @@ describe('IsMatching', () => {
             false
           >
         >,
-        Expect<Equal<IsMatching<'c' | 'd', unknown>, true>>,
+        Expect<Equal<IsMatching<{ type: 'a' }, {}>, false>>,
+        Expect<Equal<IsMatching<{}, { type: 'a' }>, false>>
+      ];
+    });
+
+    describe('Tuples', () => {
+      type cases = [
+        Expect<Equal<IsMatching<['a', 'c' | 'd'], ['a', 'd']>, true>>,
+        Expect<Equal<IsMatching<['a', 'c' | 'd'], ['a', unknown]>, true>>,
+        Expect<Equal<IsMatching<['a', 'c' | 'd'], ['a', 'f']>, false>>,
+        Expect<Equal<IsMatching<['a', 'c' | 'd'], ['b', 'c']>, false>>,
+        Expect<Equal<IsMatching<['a', 'c' | 'd', 'd'], ['b', 'c']>, false>>,
+        Expect<Equal<IsMatching<[], []>, true>>,
+        Expect<Equal<IsMatching<['a'], []>, false>>,
+        Expect<Equal<IsMatching<['a'], ['a', 'b', 'c']>, false>>,
+        Expect<Equal<IsMatching<[], ['a', 'b', 'c']>, false>>,
+
         Expect<
           Equal<
             IsMatching<
@@ -156,6 +185,65 @@ describe('IsMatching', () => {
               [{ kind: 'some'; value: { type: 'a' } }, unknown]
             >,
             true
+          >
+        >
+      ];
+    });
+
+    describe('Lists', () => {
+      type cases = [
+        Expect<Equal<IsMatching<('a' | 'b')[], 'a'[]>, true>>,
+        Expect<Equal<IsMatching<('a' | 'b')[], 'b'[]>, true>>,
+        Expect<Equal<IsMatching<('a' | 'b')[], 'c'[]>, false>>,
+        Expect<Equal<IsMatching<{ x: ['a' | 'b'] }[], { x: ['a'] }[]>, true>>,
+        Expect<Equal<IsMatching<{ x: ['a' | 'b'] }[], { x: ['c'] }[]>, false>>
+      ];
+    });
+
+    describe('Sets', () => {
+      type cases = [
+        Expect<Equal<IsMatching<Set<'a' | 'b'>, Set<'a'>>, true>>,
+        Expect<Equal<IsMatching<Set<'a' | 'b'>, Set<'b'>>, true>>,
+        Expect<Equal<IsMatching<Set<'a' | 'b'>, Set<'c'>>, false>>,
+        Expect<
+          Equal<IsMatching<Set<{ x: ['a' | 'b'] }>, Set<{ x: ['a'] }>>, true>
+        >,
+        Expect<
+          Equal<IsMatching<Set<{ x: ['a' | 'b'] }>, Set<{ x: ['c'] }>>, false>
+        >
+      ];
+    });
+
+    describe('Maps', () => {
+      type cases = [
+        Expect<
+          Equal<IsMatching<Map<string, 'a' | 'b'>, Map<string, 'a'>>, true>
+        >,
+        Expect<
+          Equal<IsMatching<Map<'hello', 'a' | 'b'>, Map<'hello', 'b'>>, true>
+        >,
+        Expect<
+          Equal<IsMatching<Map<string, 'a' | 'b'>, Map<string, 'c'>>, false>
+        >,
+        Expect<
+          Equal<IsMatching<Map<'hello', 'a' | 'b'>, Map<string, 'a'>>, false>
+        >,
+        Expect<
+          Equal<
+            IsMatching<
+              Map<string, { x: ['a' | 'b'] }>,
+              Map<string, { x: ['a'] }>
+            >,
+            true
+          >
+        >,
+        Expect<
+          Equal<
+            IsMatching<
+              Map<string, { x: ['a' | 'b'] }>,
+              Map<string, { x: ['c'] }>
+            >,
+            false
           >
         >
       ];

--- a/tests/is-matching.test.ts
+++ b/tests/is-matching.test.ts
@@ -1,0 +1,45 @@
+import { Equal, Expect } from '../src/types/helpers';
+import { IsMatching } from '../src/types/IsMatching';
+import { NotPattern } from '../src/types/Pattern';
+
+describe('IsMatching', () => {
+  it('should return true if the pattern matches the input', () => {
+    type cases = [
+      Expect<
+        Equal<
+          IsMatching<{ type: 'a'; color: 'yellow' | 'green' }, { type: 'a' }>,
+          true
+        >
+      >,
+      Expect<
+        Equal<
+          IsMatching<
+            { type: 'a'; color: 'yellow' | 'green' },
+            NotPattern<{ type: 'b' }>
+          >,
+          true
+        >
+      >
+    ];
+  });
+
+  it('should return false if the pattern does not matches the input', () => {
+    type cases = [
+      Expect<
+        Equal<
+          IsMatching<{ type: 'a'; color: 'yellow' | 'green' }, { type: 'b' }>,
+          false
+        >
+      >,
+      Expect<
+        Equal<
+          IsMatching<
+            { type: 'a'; color: 'yellow' | 'green' },
+            NotPattern<{ type: 'a' }>
+          >,
+          false
+        >
+      >
+    ];
+  });
+});

--- a/tests/is-matching.test.ts
+++ b/tests/is-matching.test.ts
@@ -1,6 +1,5 @@
 import { Equal, Expect } from '../src/types/helpers';
 import { IsMatching } from '../src/types/IsMatching';
-import { NotPattern } from '../src/types/Pattern';
 import { Option } from './utils';
 
 describe('IsMatching', () => {

--- a/tests/is-matching.test.ts
+++ b/tests/is-matching.test.ts
@@ -1,27 +1,152 @@
 import { Equal, Expect } from '../src/types/helpers';
 import { IsMatching } from '../src/types/IsMatching';
 import { NotPattern } from '../src/types/Pattern';
+import { Option } from './utils';
 
 describe('IsMatching', () => {
-  it('should return true if the pattern matches the input', () => {
-    type cases = [
-      Expect<
-        Equal<
-          IsMatching<{ type: 'a'; color: 'yellow' | 'green' }, { type: 'a' }>,
-          true
+  it('should return true if the pattern matches the input,  false otherwise', () => {
+    describe('Object', () => {
+      type cases = [
+        Expect<
+          Equal<
+            IsMatching<{ type: 'a'; color: 'yellow' | 'green' }, { type: 'a' }>,
+            true
+          >
+        >,
+        Expect<
+          Equal<
+            IsMatching<{ type: 'a'; color: 'yellow' | 'green' }, { type: 'b' }>,
+            false
+          >
+        >,
+        Expect<
+          Equal<
+            IsMatching<
+              { type: 'a'; value: { type: 'c'; value: { type: 'd' } } } | 12,
+              { type: 'a' }
+            >,
+            true
+          >
+        >,
+        Expect<
+          Equal<
+            IsMatching<
+              { type: 'a'; value: { type: 'c'; value: { type: 'd' } } } | 12,
+              12
+            >,
+            true
+          >
+        >,
+        Expect<
+          Equal<
+            IsMatching<
+              | {
+                  type: 'a';
+                  value:
+                    | { type: 'c'; value: { type: 'd' } | 2 }
+                    | { type: 'e'; value: { type: 'f' } | 3 };
+                }
+              | 12,
+              { type: 'a'; value: { type: 'c' } }
+            >,
+            true
+          >
+        >,
+        Expect<
+          Equal<
+            IsMatching<
+              | {
+                  type: 'a';
+                  value:
+                    | { type: 'c'; value: { type: 'd' } | 2 }
+                    | { type: 'e'; value: { type: 'f' } | 3 };
+                }
+              | 12,
+              { type: 'a'; value: { type: 'c'; value: 2 } }
+            >,
+            true
+          >
+        >,
+        // TODO figure out why this is matching even though it shouldn't
+        Expect<
+          Equal<
+            IsMatching<
+              | {
+                  type: 'a';
+                  value:
+                    | { type: 'c'; value: { type: 'd' } | 2 }
+                    | { type: 'e'; value: { type: 'f' } | 3 };
+                }
+              | 12,
+              { type: 'a'; value: { type: 'c'; value: 3 } }
+            >,
+            false
+          >
+        >,
+        Expect<
+          Equal<
+            IsMatching<
+              | { type: 'c'; value: { type: 'd' } | 2 }
+              | { type: 'e'; value: { type: 'f' } | 3 },
+              { type: 'c'; value: 3 }
+            >,
+            false
+          >
+        >,
+        Expect<
+          Equal<
+            IsMatching<
+              | { type: 'c'; value: { type: 'd' } | 2 }
+              | { type: 'e'; value: { type: 'f' } | 3 },
+              { type: 'c' }
+            >,
+            true
+          >
+        >,
+        Expect<
+          Equal<
+            IsMatching<
+              | { type: 'c'; value: { type: 'd' } | 2 }
+              | { type: 'e'; value: { type: 'f' } | 3 },
+              { value: 3 }
+            >,
+            true
+          >
+        >,
+        Expect<
+          Equal<
+            IsMatching<
+              { type: 'c'; value: { type: 'd' } | 2 },
+              { type: 'c'; value: 3 }
+            >,
+            false
+          >
         >
-      >
-    ];
-  });
+      ];
+    });
 
-  it('should return false if the pattern does not matches the input', () => {
-    type cases = [
-      Expect<
-        Equal<
-          IsMatching<{ type: 'a'; color: 'yellow' | 'green' }, { type: 'b' }>,
-          false
+    describe('Tuples', () => {
+      type cases = [
+        Expect<
+          Equal<
+            IsMatching<
+              Option<{ type: 'a' } | { type: 'b' }>,
+              { kind: 'some'; value: { type: 'a' } }
+            >,
+            true
+          >
+        >,
+        Expect<Equal<IsMatching<'c' | 'd', unknown>, true>>,
+        Expect<
+          Equal<
+            IsMatching<
+              [Option<{ type: 'a' } | { type: 'b' }>, 'c' | 'd'],
+              [{ kind: 'some'; value: { type: 'a' } }, unknown]
+            >,
+            true
+          >
         >
-      >
-    ];
+      ];
+    });
   });
 });

--- a/tests/is-matching.test.ts
+++ b/tests/is-matching.test.ts
@@ -10,15 +10,6 @@ describe('IsMatching', () => {
           IsMatching<{ type: 'a'; color: 'yellow' | 'green' }, { type: 'a' }>,
           true
         >
-      >,
-      Expect<
-        Equal<
-          IsMatching<
-            { type: 'a'; color: 'yellow' | 'green' },
-            NotPattern<{ type: 'b' }>
-          >,
-          true
-        >
       >
     ];
   });
@@ -28,15 +19,6 @@ describe('IsMatching', () => {
       Expect<
         Equal<
           IsMatching<{ type: 'a'; color: 'yellow' | 'green' }, { type: 'b' }>,
-          false
-        >
-      >,
-      Expect<
-        Equal<
-          IsMatching<
-            { type: 'a'; color: 'yellow' | 'green' },
-            NotPattern<{ type: 'a' }>
-          >,
           false
         >
       >

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -25,3 +25,31 @@ export type Event =
   | { type: 'success'; data: string; requestTime?: number }
   | { type: 'error'; error: Error }
   | { type: 'cancel' };
+
+export type BigUnion =
+  | 'a'
+  | 'b'
+  | 'c'
+  | 'd'
+  | 'e'
+  | 'f'
+  | 'g'
+  | 'h'
+  | 'i'
+  | 'j'
+  | 'k'
+  | 'l'
+  | 'm'
+  | 'n'
+  | 'o'
+  | 'p'
+  | 'q'
+  | 'r'
+  | 's'
+  | 't'
+  | 'u'
+  | 'v'
+  | 'w'
+  | 'x'
+  | 'y'
+  | 'z';

--- a/tests/when.test.ts
+++ b/tests/when.test.ts
@@ -100,6 +100,17 @@ describe('when', () => {
                 return true;
               }
             )
+            .with(
+              { status: 'success', data: select('data') },
+              (x) => x.data.length > 3,
+              (x) => x.data.length < 10,
+              (x) => x.data.length % 2,
+              (x) => {
+                const notNever: NotNever<typeof x> = true;
+                const inferenceCheck: { status: 'success'; data: string } = x;
+                return true;
+              }
+            )
             .otherwise(() => false)
         ).toEqual(expected);
       });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,5 +5,5 @@
     "downlevelIteration": true,
     "outDir": "lib/"
   },
-  "exclude": ["tests/", "libs/"]
+  "exclude": ["tests/", "lib/"]
 }


### PR DESCRIPTION
## Motivation
This PR is an attempt to solve the performance issue with exhaustive pattern matching on data structures containing large union types stated in this issue https://github.com/gvergnaud/ts-pattern/issues/16

## Changes

Instead of computing the union of all the possible data structures permitted by the input type upfront, this PR implements a `DeepExclude<A, B>`  type that only generate the smallest union possible based on the type of each pattern.

This strategy seems pretty promising, but I'll run some benchmarks before merging this PR.