### PR TITLE
Add support for multiple patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,22 +363,21 @@ switch (type) {
 ```
 
 Similarly, ts-pattern lets you pass several patterns to `.with()` and if
-one of these patterns matches your input, the branch will be used:
+one of these patterns matches your input, the branch will be chosen:
 
 ```ts
-const sanitize = (type: string) =>
-  match(type)
+const sanitize = (name: string) =>
+  match(name)
     .with('text', 'span', 'p', () => 'text')
     .with('btn', 'button', () => 'button')
-    .otherwise(() => type);
+    .otherwise(() => name);
 
 sanitize('span'); // 'text'
 sanitize('p'); // 'text'
 sanitize('button'); // 'button'
 ```
 
-Obviously, you can provide several complex patterns that aren't possible to express
-with regular switch statements. Exhaustive matching also works as expected.
+Obviously, you can still provide patterns that are more complex than strings, and aren't possible to express with regular switch statements. Exhaustive matching also works as you would expect.
 
 ## API Reference
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,7 @@
 ### Roadmap
 
-- [ ] add support matching again several patterns in a single `.with()` clause.
-- [ ] add a lightweight `select` API for single values
 - [ ] add a `rest` (maybe `rest(Pattern<a>)`) pattern for list. Example of using `rest`:
+- [ ] maybe add a lightweight `select` API for single values
 
 ```ts
 const reverse2 = <T>(xs: T[]): T[] => {
@@ -14,6 +13,7 @@ const reverse2 = <T>(xs: T[]): T[] => {
 
 - [ ] When not provided, maybe compute the output type from all branches
 - [ ] Maybe change the syntax for list, and provide a `__.list` pattern, so we can support unary tuples
+- [x] add support matching again several patterns in a single `.with()` clause.
 - [x] Find a way to enforce exhaustive pattern matching
 - [x] Several pattern/when clauses if necessary, with refined type inference from one to the other
 - [x] Find a way to make the full type inference work

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "2.1.6",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "2.2.1-next.0",
+  "version": "2.2.1-next.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3486,9 +3486,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true
     },
     "pretty-format": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "2.2.1-next.1",
+  "version": "2.2.1-next.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "2.2.1-next.2",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "2.2.0",
+  "version": "2.2.1-next.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "2.1.6",
+  "version": "2.2.0",
   "description": "Typescript pattern matching library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "2.2.1-next.2",
+  "version": "2.2.1",
   "description": "Typescript pattern matching library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "2.2.0",
+  "version": "2.2.1-next.0",
   "description": "Typescript pattern matching library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "2.2.1-next.0",
+  "version": "2.2.1-next.1",
   "description": "Typescript pattern matching library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "2.2.1-next.1",
+  "version": "2.2.1-next.2",
   "description": "Typescript pattern matching library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.15",
     "jest": "^26.6.3",
-    "prettier": "^2.0.5",
+    "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.4.4",
     "typescript": "^4.2.2"

--- a/src/types/DeepExclude.ts
+++ b/src/types/DeepExclude.ts
@@ -1,3 +1,10 @@
 import { DistributeMatchingUnions } from './DistributeUnions';
+import { UnionToTuple } from './helpers';
 
 export type DeepExclude<a, b> = Exclude<DistributeMatchingUnions<a, b>, b>;
+
+export type ReduceDeepExclude<a, xs> = xs extends [infer head, ...infer tail]
+  ? ReduceDeepExclude<DeepExclude<a, head>, tail>
+  : a;
+
+export type DeepExcludeMany<a, b> = ReduceDeepExclude<a, UnionToTuple<b>>;

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -39,6 +39,19 @@ export type Match<i, o> = {
   ): Match<i, PickReturnValue<o, c>>;
 
   with<
+    ps extends ExhaustivePattern<i>[],
+    c,
+    value = ps[number] extends infer p
+      ? p extends any 
+        ? MatchedValue<i, InvertPattern<p>>
+        : never
+      : never
+  >(...args: [
+    ...patterns: ps,
+    handler: (value: value) => PickReturnValue<o, c>
+  ]): Match<i, PickReturnValue<o, c>>;
+
+  with<
     pat extends Pattern<i>,
     pred extends (value: MatchedValue<i, InvertPattern<pat>>) => unknown,
     c
@@ -147,6 +160,32 @@ export type ExhaustiveMatch<distributedInput, i, o> = {
     // in it, because Pattern<i> is generally mucb easier to compute than
     // the Pattern<distributedInput>.
     DeepExclude<distributedInput, InvertNotPattern<invpattern, value>>,
+    i,
+    PickReturnValue<o, c>
+  >;
+  with<
+    ps extends [ExhaustivePattern<i>, ...ExhaustivePattern<i>[]],
+    c,
+    value = ps[number] extends infer p
+      ? p extends any 
+        ? MatchedValue<i, InvertPattern<p>>
+        : never
+      : never
+  >(...args: [
+    ...patterns: ps,
+    handler: (value: value) => PickReturnValue<o, c>
+  ]): ExhaustiveMatch<
+    // For performances, keep the origin input `i` even after we call DeepExclude
+    // in it, because Pattern<i> is generally mucb easier to compute than
+    // the Pattern<distributedInput>.
+    DeepExclude<
+      distributedInput,
+      ps[number] extends infer p
+        ? p extends any
+          ? InvertNotPattern<InvertPattern<p>, value>
+          : never
+        : never
+    >,
     i,
     PickReturnValue<o, c>
   >;

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -39,7 +39,7 @@ export type Match<i, o> = {
   ): Match<i, PickReturnValue<o, c>>;
 
   with<
-    ps extends [ExhaustivePattern<i>, ...ExhaustivePattern<i>[]],
+    ps extends [Pattern<i>, ...Pattern<i>[]],
     c,
     p = ps[number],
     value = p extends any ? MatchedValue<i, InvertPattern<p>> : never

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -39,32 +39,6 @@ export type Match<i, o> = {
   ): Match<i, PickReturnValue<o, c>>;
 
   with<
-    p1 extends ExhaustivePattern<i>,
-    p2 extends ExhaustivePattern<i>,
-    c,
-    p = p1 | p2,
-    value = p extends any ? MatchedValue<i, InvertPattern<p>> : never
-  >(
-    pattern1: p1,
-    pattern2: p2,
-    handler: (value: value) => PickReturnValue<o, c>
-  ): Match<i, PickReturnValue<o, c>>;
-
-  with<
-    p1 extends ExhaustivePattern<i>,
-    p2 extends ExhaustivePattern<i>,
-    p3 extends ExhaustivePattern<i>,
-    c,
-    p = p1 | p2 | p3,
-    value = p extends any ? MatchedValue<i, InvertPattern<p>> : never
-  >(
-    pattern1: p1,
-    pattern2: p2,
-    pattern3: p3,
-    handler: (value: value) => PickReturnValue<o, c>
-  ): Match<i, PickReturnValue<o, c>>;
-
-  with<
     ps extends [ExhaustivePattern<i>, ...ExhaustivePattern<i>[]],
     c,
     p = ps[number],
@@ -182,46 +156,6 @@ export type ExhaustiveMatch<distributedInput, i, o> = {
     // in it, because Pattern<i> is generally mucb easier to compute than
     // the Pattern<distributedInput>.
     DeepExclude<distributedInput, InvertNotPattern<invpattern, value>>,
-    i,
-    PickReturnValue<o, c>
-  >;
-
-  with<
-    p1 extends ExhaustivePattern<i>,
-    p2 extends ExhaustivePattern<i>,
-    c,
-    p = p1 | p2,
-    value = p extends any ? MatchedValue<i, InvertPattern<p>> : never
-  >(
-    pattern1: p1,
-    pattern2: p2,
-    handler: (value: value) => PickReturnValue<o, c>
-  ): ExhaustiveMatch<
-    DeepExclude<
-      distributedInput,
-      p extends any ? InvertNotPattern<InvertPattern<p>, value> : never
-    >,
-    i,
-    PickReturnValue<o, c>
-  >;
-
-  with<
-    p1 extends ExhaustivePattern<i>,
-    p2 extends ExhaustivePattern<i>,
-    p3 extends ExhaustivePattern<i>,
-    c,
-    p = p1 | p2 | p3,
-    value = p extends any ? MatchedValue<i, InvertPattern<p>> : never
-  >(
-    pattern1: p1,
-    pattern2: p2,
-    pattern3: p3,
-    handler: (value: value) => PickReturnValue<o, c>
-  ): ExhaustiveMatch<
-    DeepExcludeMany<
-      distributedInput,
-      p extends any ? InvertNotPattern<InvertPattern<p>, value> : never
-    >,
     i,
     PickReturnValue<o, c>
   >;

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -39,7 +39,7 @@ export type Match<i, o> = {
   ): Match<i, PickReturnValue<o, c>>;
 
   with<
-    ps extends ExhaustivePattern<i>[],
+    ps extends [ExhaustivePattern<i>, ...ExhaustivePattern<i>[]],
     c,
     value = ps[number] extends infer p
       ? p extends any 
@@ -163,28 +163,24 @@ export type ExhaustiveMatch<distributedInput, i, o> = {
     i,
     PickReturnValue<o, c>
   >;
+
   with<
     ps extends [ExhaustivePattern<i>, ...ExhaustivePattern<i>[]],
     c,
-    value = ps[number] extends infer p
-      ? p extends any 
-        ? MatchedValue<i, InvertPattern<p>>
-        : never
-      : never
-  >(...args: [
-    ...patterns: ps,
-    handler: (value: value) => PickReturnValue<o, c>
-  ]): ExhaustiveMatch<
+    p = ps[number],
+    value = p extends any ? MatchedValue<i, InvertPattern<p>> : never
+  >(
+    ...args: [
+      ...patterns: ps,
+      handler: (value: value) => PickReturnValue<o, c>
+    ]
+  ): ExhaustiveMatch<
     // For performances, keep the origin input `i` even after we call DeepExclude
     // in it, because Pattern<i> is generally mucb easier to compute than
     // the Pattern<distributedInput>.
     DeepExclude<
       distributedInput,
-      ps[number] extends infer p
-        ? p extends any
-          ? InvertNotPattern<InvertPattern<p>, value>
-          : never
-        : never
+      p extends any ? InvertNotPattern<InvertPattern<p>, value> : never
     >,
     i,
     PickReturnValue<o, c>

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -39,12 +39,63 @@ export type Match<i, o> = {
   ): Match<i, PickReturnValue<o, c>>;
 
   with<
-    ps extends [Pattern<i>, ...Pattern<i>[]],
+    p1 extends Pattern<i>,
+    p2 extends Pattern<i>,
     c,
-    p = ps[number],
+    p = p1 | p2,
     value = p extends any ? MatchedValue<i, InvertPattern<p>> : never
   >(
-    ...args: [...patterns: ps, handler: (value: value) => PickReturnValue<o, c>]
+    pattern1: p1,
+    pattern2: p2,
+    handler: (value: value) => PickReturnValue<o, c>
+  ): Match<i, PickReturnValue<o, c>>;
+
+  with<
+    p1 extends Pattern<i>,
+    p2 extends Pattern<i>,
+    p3 extends Pattern<i>,
+    c,
+    p = p1 | p2 | p3,
+    value = p extends any ? MatchedValue<i, InvertPattern<p>> : never
+  >(
+    pattern1: p1,
+    pattern2: p2,
+    pattern3: p3,
+    handler: (value: value) => PickReturnValue<o, c>
+  ): Match<i, PickReturnValue<o, c>>;
+
+  with<
+    p1 extends Pattern<i>,
+    p2 extends Pattern<i>,
+    p3 extends Pattern<i>,
+    p4 extends Pattern<i>,
+    c,
+    p = p1 | p2 | p3 | p4,
+    value = p extends any ? MatchedValue<i, InvertPattern<p>> : never
+  >(
+    pattern1: p1,
+    pattern2: p2,
+    pattern3: p3,
+    pattern4: p4,
+    handler: (value: value) => PickReturnValue<o, c>
+  ): Match<i, PickReturnValue<o, c>>;
+
+  with<
+    p1 extends Pattern<i>,
+    p2 extends Pattern<i>,
+    p3 extends Pattern<i>,
+    p4 extends Pattern<i>,
+    p5 extends Pattern<i>,
+    c,
+    p = p1 | p2 | p3 | p4 | p5,
+    value = p extends any ? MatchedValue<i, InvertPattern<p>> : never
+  >(
+    pattern1: p1,
+    pattern2: p2,
+    pattern3: p3,
+    pattern4: p4,
+    pattern5: p5,
+    handler: (value: value) => PickReturnValue<o, c>
   ): Match<i, PickReturnValue<o, c>>;
 
   with<
@@ -161,12 +212,84 @@ export type ExhaustiveMatch<distributedInput, i, o> = {
   >;
 
   with<
-    ps extends [ExhaustivePattern<i>, ...ExhaustivePattern<i>[]],
+    p1 extends ExhaustivePattern<i>,
+    p2 extends ExhaustivePattern<i>,
     c,
-    p = ps[number],
+    p = p1 | p2,
     value = p extends any ? MatchedValue<i, InvertPattern<p>> : never
   >(
-    ...args: [...patterns: ps, handler: (value: value) => PickReturnValue<o, c>]
+    pattern1: p1,
+    pattern2: p2,
+    handler: (value: value) => PickReturnValue<o, c>
+  ): ExhaustiveMatch<
+    DeepExcludeMany<
+      distributedInput,
+      p extends any ? InvertNotPattern<InvertPattern<p>, value> : never
+    >,
+    i,
+    PickReturnValue<o, c>
+  >;
+
+  with<
+    p1 extends ExhaustivePattern<i>,
+    p2 extends ExhaustivePattern<i>,
+    p3 extends ExhaustivePattern<i>,
+    c,
+    p = p1 | p2 | p3,
+    value = p extends any ? MatchedValue<i, InvertPattern<p>> : never
+  >(
+    pattern1: p1,
+    pattern2: p2,
+    pattern3: p3,
+    handler: (value: value) => PickReturnValue<o, c>
+  ): ExhaustiveMatch<
+    DeepExcludeMany<
+      distributedInput,
+      p extends any ? InvertNotPattern<InvertPattern<p>, value> : never
+    >,
+    i,
+    PickReturnValue<o, c>
+  >;
+
+  with<
+    p1 extends ExhaustivePattern<i>,
+    p2 extends ExhaustivePattern<i>,
+    p3 extends ExhaustivePattern<i>,
+    p4 extends ExhaustivePattern<i>,
+    c,
+    p = p1 | p2 | p3 | p4,
+    value = p extends any ? MatchedValue<i, InvertPattern<p>> : never
+  >(
+    pattern1: p1,
+    pattern2: p2,
+    pattern3: p3,
+    pattern4: p4,
+    handler: (value: value) => PickReturnValue<o, c>
+  ): ExhaustiveMatch<
+    DeepExcludeMany<
+      distributedInput,
+      p extends any ? InvertNotPattern<InvertPattern<p>, value> : never
+    >,
+    i,
+    PickReturnValue<o, c>
+  >;
+
+  with<
+    p1 extends ExhaustivePattern<i>,
+    p2 extends ExhaustivePattern<i>,
+    p3 extends ExhaustivePattern<i>,
+    p4 extends ExhaustivePattern<i>,
+    p5 extends ExhaustivePattern<i>,
+    c,
+    p = p1 | p2 | p3 | p4 | p5,
+    value = p extends any ? MatchedValue<i, InvertPattern<p>> : never
+  >(
+    pattern1: p1,
+    pattern2: p2,
+    pattern3: p3,
+    pattern4: p4,
+    pattern5: p5,
+    handler: (value: value) => PickReturnValue<o, c>
   ): ExhaustiveMatch<
     DeepExcludeMany<
       distributedInput,

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -1,7 +1,7 @@
 import type { Pattern, GuardValue, ExhaustivePattern } from './Pattern';
 import type { ExtractPreciseValue } from './ExtractPreciseValue';
 import type { InvertNotPattern, InvertPattern } from './InvertPattern';
-import type { DeepExclude } from './DeepExclude';
+import type { DeepExclude, DeepExcludeMany } from './DeepExclude';
 import type { WithDefault } from './helpers';
 import type { FindSelected } from './FindSelected';
 
@@ -39,17 +39,39 @@ export type Match<i, o> = {
   ): Match<i, PickReturnValue<o, c>>;
 
   with<
+    p1 extends ExhaustivePattern<i>,
+    p2 extends ExhaustivePattern<i>,
+    c,
+    p = p1 | p2,
+    value = p extends any ? MatchedValue<i, InvertPattern<p>> : never
+  >(
+    pattern1: p1,
+    pattern2: p2,
+    handler: (value: value) => PickReturnValue<o, c>
+  ): Match<i, PickReturnValue<o, c>>;
+
+  with<
+    p1 extends ExhaustivePattern<i>,
+    p2 extends ExhaustivePattern<i>,
+    p3 extends ExhaustivePattern<i>,
+    c,
+    p = p1 | p2 | p3,
+    value = p extends any ? MatchedValue<i, InvertPattern<p>> : never
+  >(
+    pattern1: p1,
+    pattern2: p2,
+    pattern3: p3,
+    handler: (value: value) => PickReturnValue<o, c>
+  ): Match<i, PickReturnValue<o, c>>;
+
+  with<
     ps extends [ExhaustivePattern<i>, ...ExhaustivePattern<i>[]],
     c,
-    value = ps[number] extends infer p
-      ? p extends any 
-        ? MatchedValue<i, InvertPattern<p>>
-        : never
-      : never
-  >(...args: [
-    ...patterns: ps,
-    handler: (value: value) => PickReturnValue<o, c>
-  ]): Match<i, PickReturnValue<o, c>>;
+    p = ps[number],
+    value = p extends any ? MatchedValue<i, InvertPattern<p>> : never
+  >(
+    ...args: [...patterns: ps, handler: (value: value) => PickReturnValue<o, c>]
+  ): Match<i, PickReturnValue<o, c>>;
 
   with<
     pat extends Pattern<i>,
@@ -165,20 +187,54 @@ export type ExhaustiveMatch<distributedInput, i, o> = {
   >;
 
   with<
+    p1 extends ExhaustivePattern<i>,
+    p2 extends ExhaustivePattern<i>,
+    c,
+    p = p1 | p2,
+    value = p extends any ? MatchedValue<i, InvertPattern<p>> : never
+  >(
+    pattern1: p1,
+    pattern2: p2,
+    handler: (value: value) => PickReturnValue<o, c>
+  ): ExhaustiveMatch<
+    DeepExclude<
+      distributedInput,
+      p extends any ? InvertNotPattern<InvertPattern<p>, value> : never
+    >,
+    i,
+    PickReturnValue<o, c>
+  >;
+
+  with<
+    p1 extends ExhaustivePattern<i>,
+    p2 extends ExhaustivePattern<i>,
+    p3 extends ExhaustivePattern<i>,
+    c,
+    p = p1 | p2 | p3,
+    value = p extends any ? MatchedValue<i, InvertPattern<p>> : never
+  >(
+    pattern1: p1,
+    pattern2: p2,
+    pattern3: p3,
+    handler: (value: value) => PickReturnValue<o, c>
+  ): ExhaustiveMatch<
+    DeepExcludeMany<
+      distributedInput,
+      p extends any ? InvertNotPattern<InvertPattern<p>, value> : never
+    >,
+    i,
+    PickReturnValue<o, c>
+  >;
+
+  with<
     ps extends [ExhaustivePattern<i>, ...ExhaustivePattern<i>[]],
     c,
     p = ps[number],
     value = p extends any ? MatchedValue<i, InvertPattern<p>> : never
   >(
-    ...args: [
-      ...patterns: ps,
-      handler: (value: value) => PickReturnValue<o, c>
-    ]
+    ...args: [...patterns: ps, handler: (value: value) => PickReturnValue<o, c>]
   ): ExhaustiveMatch<
-    // For performances, keep the origin input `i` even after we call DeepExclude
-    // in it, because Pattern<i> is generally mucb easier to compute than
-    // the Pattern<distributedInput>.
-    DeepExclude<
+    DeepExcludeMany<
       distributedInput,
       p extends any ? InvertNotPattern<InvertPattern<p>, value> : never
     >,

--- a/tests/deep-exclude.test.ts
+++ b/tests/deep-exclude.test.ts
@@ -1,4 +1,4 @@
-import { DeepExclude } from '../src/types/DeepExclude';
+import { DeepExclude, DeepExcludeMany } from '../src/types/DeepExclude';
 import { Equal, Expect } from '../src/types/helpers';
 import { Primitives } from '../src/types/Pattern';
 import { BigUnion, Option } from './utils';
@@ -267,69 +267,95 @@ describe('DeepExclude', () => {
     ];
   });
 
-  it('should work in common cases', () => {});
-  type cases = [
-    Expect<Equal<DeepExclude<'a' | 'b' | 'c', 'a'>, 'b' | 'c'>>,
-    Expect<
-      Equal<
-        DeepExclude<
-          | { type: 'textWithColor'; color: Colors }
-          | {
-              type: 'textWithColorAndBackground';
-              color: Colors;
-              backgroundColor: Colors;
-            },
-          { type: 'textWithColor' }
-        >,
-        {
-          type: 'textWithColorAndBackground';
-          color: Colors;
-          backgroundColor: Colors;
-        }
-      >
-    >,
-    Expect<
-      Equal<
-        DeepExclude<
-          | { type: 'textWithColor'; color: Colors }
-          | {
-              type: 'textWithColorAndBackground';
-              color: Colors;
-              backgroundColor: Colors;
-            },
-          { type: 'textWithColor'; color: 'pink' }
-        >,
-        | {
+  it('should work in common cases', () => {
+    type cases = [
+      Expect<Equal<DeepExclude<'a' | 'b' | 'c', 'a'>, 'b' | 'c'>>,
+      Expect<
+        Equal<
+          DeepExclude<
+            | { type: 'textWithColor'; color: Colors }
+            | {
+                type: 'textWithColorAndBackground';
+                color: Colors;
+                backgroundColor: Colors;
+              },
+            { type: 'textWithColor' }
+          >,
+          {
             type: 'textWithColorAndBackground';
             color: Colors;
             backgroundColor: Colors;
           }
-        | { type: 'textWithColor'; color: 'purple' }
-        | { type: 'textWithColor'; color: 'red' }
-        | { type: 'textWithColor'; color: 'yellow' }
-        | { type: 'textWithColor'; color: 'blue' }
+        >
+      >,
+      Expect<
+        Equal<
+          DeepExclude<
+            | { type: 'textWithColor'; color: Colors }
+            | {
+                type: 'textWithColorAndBackground';
+                color: Colors;
+                backgroundColor: Colors;
+              },
+            { type: 'textWithColor'; color: 'pink' }
+          >,
+          | {
+              type: 'textWithColorAndBackground';
+              color: Colors;
+              backgroundColor: Colors;
+            }
+          | { type: 'textWithColor'; color: 'purple' }
+          | { type: 'textWithColor'; color: 'red' }
+          | { type: 'textWithColor'; color: 'yellow' }
+          | { type: 'textWithColor'; color: 'blue' }
+        >
+      >,
+      Expect<
+        Equal<
+          DeepExclude<
+            [Option<{ type: 'a' } | { type: 'b' }>, 'c' | 'd'],
+            [{ kind: 'some'; value: { type: 'a' } }, any]
+          >,
+          | [{ kind: 'none' }, 'c' | 'd']
+          | [{ kind: 'some'; value: { type: 'b' } }, 'c' | 'd']
+        >
+      >,
+      Expect<
+        Equal<
+          DeepExclude<
+            { x: 'a' | 'b'; y: 'c' | 'd'; z: 'e' | 'f' },
+            { x: 'a'; y: 'c' }
+          >,
+          | { x: 'b'; y: 'c'; z: 'e' | 'f' }
+          | { x: 'b'; y: 'd'; z: 'e' | 'f' }
+          | { x: 'a'; y: 'd'; z: 'e' | 'f' }
+        >
       >
-    >,
-    Expect<
-      Equal<
-        DeepExclude<
-          [Option<{ type: 'a' } | { type: 'b' }>, 'c' | 'd'],
-          [{ kind: 'some'; value: { type: 'a' } }, any]
+    ];
+  });
+
+  describe('Multiple patterns', () => {
+    it('should work when pattern is a union', () => {
+      type cases = [
+        Expect<
+          Equal<
+            DeepExcludeMany<
+              { x: 'a' | 'b'; y: 'c' | 'd'; z: 'e' | 'f' },
+              { x: 'a'; y: 'c' } | { x: 'b'; y: 'c' }
+            >,
+            { x: 'b'; y: 'd'; z: 'e' | 'f' } | { x: 'a'; y: 'd'; z: 'e' | 'f' }
+          >
         >,
-        | [{ kind: 'none' }, 'c' | 'd']
-        | [{ kind: 'some'; value: { type: 'b' } }, 'c' | 'd']
-      >
-    >,
-    Expect<
-      Equal<
-        DeepExclude<
-          { x: 'a' | 'b'; y: 'c' | 'd'; z: 'e' | 'f' },
-          { x: 'a'; y: 'c' }
-        >,
-        | { x: 'b'; y: 'c'; z: 'e' | 'f' }
-        | { x: 'b'; y: 'd'; z: 'e' | 'f' }
-        | { x: 'a'; y: 'd'; z: 'e' | 'f' }
-      >
-    >
-  ];
+        Expect<
+          Equal<
+            DeepExcludeMany<
+              { a: { b: 'x' | 'y' | 'z' }; c: 'u' | 'v' },
+              { c: 'u' } | { a: { b: 'x' } }
+            >,
+            { a: { b: 'y' }; c: 'v' } | { a: { b: 'z' }; c: 'v' }
+          >
+        >
+      ];
+    });
+  });
 });

--- a/tests/exhaustive-match.test.ts
+++ b/tests/exhaustive-match.test.ts
@@ -557,23 +557,21 @@ describe('exhaustive()', () => {
 
     it('should work with inputs of varying shapes', () => {
       type Input = { type: 'test' } | ['hello', Option<string>] | 'hello'[];
-      type Output = ['hello', Option<string>];
       const input = { type: 'test' } as Input;
 
-      const output = match(input)
-        .exhaustive()
-        .with(
-          ['hello', { kind: 'some' }],
-          (x): Output => {
-            return x;
-          }
-        )
-        .with(['hello'], (x) => {
-          return ['hello', none];
-        })
-        .with({ type: __ }, () => ['hello', none])
-        .with([__], () => ['hello', none])
-        .run();
+      expect(
+        match(input)
+          .exhaustive()
+          .with(['hello', { kind: 'some' }], ([, { value }]) => {
+            return value;
+          })
+          .with(['hello'], ([str]) => {
+            return str;
+          })
+          .with({ type: __ }, (x) => x.type)
+          .with([__], (x) => `("hello" | Option<string>)[] | "hello"[]`)
+          .run()
+      ).toEqual('test');
     });
   });
 });

--- a/tests/exhaustive-match.test.ts
+++ b/tests/exhaustive-match.test.ts
@@ -8,7 +8,7 @@ describe('exhaustive()', () => {
       .with(
         {
           kind: 'some',
-          // @ts-expect-error
+          // @ts-expect-error: x is unknown
           value: when((x) => x > 2),
         },
         () => true
@@ -19,11 +19,10 @@ describe('exhaustive()', () => {
       .exhaustive()
       .with(
         { kind: 'some' },
+        // @ts-expect-error: value is unknown
         ({ value }) => value > 2,
-        // @ts-expect-error
         () => true
       )
-      // @ts-expect-error
       .run();
   });
 
@@ -239,6 +238,13 @@ describe('exhaustive()', () => {
         .exhaustive()
         .with({ kind: 'some' }, ({ value }) => value)
         .with({ kind: 'none' }, () => 0)
+        .run();
+
+      match<Option<number>>({ kind: 'some', value: 3 })
+        .exhaustive()
+        .with({ kind: 'some', value: 3 as const }, ({ value }): number => value)
+        .with({ kind: 'none' }, () => 0)
+        // @ts-expect-error: missing {kind: 'some', value: number}
         .run();
     });
 

--- a/tests/multiple-patterns.test.ts
+++ b/tests/multiple-patterns.test.ts
@@ -1,0 +1,46 @@
+import { match, not, when, __ } from '../src';
+import { Option, some, none, BigUnion } from './utils';
+
+describe('Multiple patterns', () => {
+  it('should match if one of the patterns match', () => {
+    const testFn = (input: Option<number>) =>
+      match(input)
+        .exhaustive()
+        .with(
+          { kind: 'some', value: 2 },
+          { kind: 'some', value: 3 },
+          { kind: 'some', value: 4 },
+          (x) => true
+        )
+        .with({ kind: 'none' }, { kind: 'some' }, () => false)
+        .run();
+
+    const cases = [
+      { input: { kind: 'some', value: 3 }, expected: true },
+      { input: { kind: 'some', value: 2 }, expected: true },
+      { input: { kind: 'some', value: 4 }, expected: true },
+      { input: { kind: 'some', value: 5 }, expected: false },
+      { input: { kind: 'some', value: -5 }, expected: false },
+    ] as const;
+
+    cases.forEach(({ input, expected }) => {
+      expect(testFn(input)).toBe(expected);
+    });
+  });
+
+  it("no patterns shouldn't typecheck", () => {
+    const testFn = (input: Option<number>) =>
+      match(input)
+        .exhaustive()
+        .with(
+          { kind: 'some', value: 2 },
+          { kind: 'some', value: 3 },
+          { kind: 'some', value: 4 },
+          (x) => true
+        )
+        .with({ kind: 'none' }, { kind: 'some' }, () => false)
+        // @ts-expect-error: Argument of type '() => false' is not assignable to parameter of type 'ExhaustivePattern<Option<number>>'
+        .with(() => false)
+        .run();
+  });
+});

--- a/tests/multiple-patterns.test.ts
+++ b/tests/multiple-patterns.test.ts
@@ -3,7 +3,47 @@ import { Option, some, none, BigUnion } from './utils';
 import { Expect, Equal } from '../src/types/helpers';
 
 describe('Multiple patterns', () => {
-  it('should match if one of the patterns match', () => {
+  it('should match if one of the patterns matches', () => {
+    const testFn = (input: Option<number>) =>
+      match(input)
+        .with(
+          { kind: 'some', value: 2 as const },
+          { kind: 'some', value: 3 as const },
+          { kind: 'some', value: 4 as const },
+          (x) => {
+            type t = Expect<
+              Equal<
+                typeof x,
+                | { kind: 'some'; value: 2 }
+                | { kind: 'some'; value: 3 }
+                | { kind: 'some'; value: 4 }
+              >
+            >;
+            return true;
+          }
+        )
+        .with({ kind: 'none' }, { kind: 'some' }, (x) => {
+          type t = Expect<
+            Equal<typeof x, { kind: 'some'; value: number } | { kind: 'none' }>
+          >;
+          return false;
+        })
+        .run();
+
+    const cases = [
+      { input: { kind: 'some', value: 3 }, expected: true },
+      { input: { kind: 'some', value: 2 }, expected: true },
+      { input: { kind: 'some', value: 4 }, expected: true },
+      { input: { kind: 'some', value: 5 }, expected: false },
+      { input: { kind: 'some', value: -5 }, expected: false },
+    ] as const;
+
+    cases.forEach(({ input, expected }) => {
+      expect(testFn(input)).toBe(expected);
+    });
+  });
+
+  it('exhaustive patterns should match if one of the patterns matches', () => {
     const testFn = (input: Option<number>) =>
       match(input)
         .exhaustive()
@@ -49,13 +89,11 @@ describe('Multiple patterns', () => {
     match(input)
       .exhaustive()
       // @ts-expect-error: Argument of type '() => false' is not assignable to parameter of type 'ExhaustivePattern<Option<number>>'
-      .with(() => false)
-      .run();
+      .with(() => false);
 
     match(input)
       // @ts-expect-error: Argument of type '() => false' is not assignable to parameter of type 'ExhaustivePattern<Option<number>>'
-      .with(() => false)
-      .run();
+      .with(() => false);
 
     match(input)
       .exhaustive()
@@ -67,9 +105,7 @@ describe('Multiple patterns', () => {
         { kind: 'some', value: 4 as const },
         (x) => true
       )
-      .with({ kind: 'none' }, { kind: 'some' }, () => false)
-
-      .run();
+      .with({ kind: 'none' }, { kind: 'some' }, () => false);
   });
 
   it('should work with all types of input', () => {


### PR DESCRIPTION
This PR adds support for matching several pattern on a single `.with()` clause.

```ts
type Input = 1 | 2 | 3 | 4 | 5 | 6;

const output = match<Input>(1)
    .with(1, 2, x => {...}) // x: 1 | 2
    .with(3, x => {...}) // x: 3
    .with(4, 5, 6, x => {...}) // x: 4 | 5 | 6
    .run();
```

