### PR TITLE
Gabriel.vergnaud/infer output as a union 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "3.0.6",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "3.1.0",
+  "version": "3.1.1-next.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "3.0.6",
+  "version": "3.1.0",
   "description": "Typescript pattern matching library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "3.1.0",
+  "version": "3.1.1-next.0",
   "description": "Typescript pattern matching library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -2,7 +2,7 @@ import type { Pattern, GuardValue, GuardPattern } from './Pattern';
 import type { ExtractPreciseValue } from './ExtractPreciseValue';
 import type { InvertPatternForExclude, InvertPattern } from './InvertPattern';
 import type { DeepExclude } from './DeepExclude';
-import type { WithDefault } from './helpers';
+import type { WithDefault, Union } from './helpers';
 import type { FindSelected } from './FindSelected';
 
 // We fall back to `a` if we weren't able to extract anything more precise
@@ -14,8 +14,6 @@ export type MatchedValue<a, invpattern> = WithDefault<
 export type Unset = '@ts-pattern/unset';
 
 export type PickReturnValue<a, b> = a extends Unset ? b : a;
-
-type Union<a, b> = [b] extends [a] ? a : [a] extends [b] ? b : a | b;
 
 type NonExhaustiveError<i> = { __nonExhaustive: never } & i;
 
@@ -41,12 +39,7 @@ export type Match<
       selections: FindSelected<value, p>,
       value: value
     ) => PickReturnValue<o, c>
-  ): Match<
-    i,
-    o,
-    patternValueTuples | [p, value],
-    PickReturnValue<o, Union<inferredOutput, c>>
-  >;
+  ): Match<i, o, patternValueTuples | [p, value], Union<inferredOutput, c>>;
 
   with<
     p1 extends Pattern<i>,

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -15,7 +15,7 @@ export type Unset = '@ts-pattern/unset';
 
 export type PickReturnValue<a, b> = a extends Unset ? b : a;
 
-type Union<a, b> = b extends a ? a : a | b;
+type Union<a, b> = [b] extends [a] ? a : [a] extends [b] ? b : a | b;
 
 type NonExhaustiveError<i> = { __nonExhaustive: never } & i;
 
@@ -27,7 +27,7 @@ export type Match<
   i,
   o,
   patternValueTuples extends [any, any] = never,
-  inferedOutput = never
+  inferredOutput = never
 > = {
   /**
    * #### Match.with
@@ -45,7 +45,7 @@ export type Match<
     i,
     o,
     patternValueTuples | [p, value],
-    PickReturnValue<o, Union<inferedOutput, c>>
+    PickReturnValue<o, Union<inferredOutput, c>>
   >;
 
   with<
@@ -62,7 +62,7 @@ export type Match<
     i,
     o,
     patternValueTuples | (p extends any ? [p, value] : never),
-    Union<inferedOutput, c>
+    Union<inferredOutput, c>
   >;
 
   with<
@@ -84,7 +84,7 @@ export type Match<
     | (pred extends (value: any) => value is infer narrowed
         ? [GuardPattern<unknown, narrowed>, value]
         : never),
-    Union<inferedOutput, c>
+    Union<inferredOutput, c>
   >;
 
   with<
@@ -98,7 +98,7 @@ export type Match<
     i,
     o,
     patternValueTuples | (p extends any ? [p, value] : never),
-    Union<inferedOutput, c>
+    Union<inferredOutput, c>
   >;
 
   /**
@@ -117,7 +117,7 @@ export type Match<
     | (pred extends (value: any) => value is infer narrowed
         ? [GuardPattern<unknown, narrowed>, value]
         : never),
-    Union<inferedOutput, c>
+    Union<inferredOutput, c>
   >;
 
   /**
@@ -130,7 +130,7 @@ export type Match<
    **/
   otherwise: <c>(
     handler: () => PickReturnValue<o, c>
-  ) => PickReturnValue<o, Union<inferedOutput, c>>;
+  ) => PickReturnValue<o, Union<inferredOutput, c>>;
 
   /**
    * #### Match.exhaustive
@@ -144,7 +144,7 @@ export type Match<
    * */
   exhaustive: DeepExcludeAll<i, patternValueTuples> extends infer remainingCases
     ? [remainingCases] extends [never]
-      ? () => PickReturnValue<o, inferedOutput>
+      ? () => PickReturnValue<o, inferredOutput>
       : NonExhaustiveError<remainingCases>
     : never;
 
@@ -152,7 +152,7 @@ export type Match<
    * #### Match.run
    * Runs the pattern matching expression and return the result.
    * */
-  run: () => PickReturnValue<o, inferedOutput>;
+  run: () => PickReturnValue<o, inferredOutput>;
 };
 
 type DeepExcludeAll<a, tuple extends [any, any]> = DeepExclude<

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -174,3 +174,5 @@ export type Primitives =
   | null
   | symbol
   | bigint;
+
+export type Union<a, b> = [b] extends [a] ? a : [a] extends [b] ? b : a | b;

--- a/tests/multiple-patterns.test.ts
+++ b/tests/multiple-patterns.test.ts
@@ -230,7 +230,7 @@ describe('Multiple patterns', () => {
 
   it("when 2 returned values don't match, the error should be at the second returned value", () => {
     const f = (input: { t: 'a'; x: any } | { t: 'b' }) =>
-      match(input)
+      match<typeof input, string>(input)
         .with({ t: 'a', x: 'hello' }, { t: 'a' }, (x) => 'ok')
         // @ts-expect-error
         .with({ t: 'b' }, (x) => 2)

--- a/tests/output-type.test.ts
+++ b/tests/output-type.test.ts
@@ -1,0 +1,167 @@
+import { match, __ } from '../src';
+import { Equal, Expect } from '../src/types/helpers';
+import { State } from './utils';
+
+describe('output type', () => {
+  describe('exhaustive', () => {
+    it('should return a single type if they are all compatible', () => {
+      const f = (input: number) =>
+        match(input)
+          .with(1, () => 'ok')
+          .with(2, () => 'test')
+          .with(__, () => 'hello')
+          .exhaustive();
+
+      type o1 = Expect<Equal<ReturnType<typeof f>, string>>;
+
+      const f2 = (input: number) =>
+        match(input)
+          .with(1, () => ({ x: 'ok' }))
+          .with(2, () => ({ x: 'test' }))
+          .with(__, () => ({ x: 'hello' }))
+          .exhaustive();
+
+      type o2 = Expect<Equal<ReturnType<typeof f2>, { x: string }>>;
+
+      const f3 = (input: number) =>
+        match(input)
+          .with(1, () => [1, 2, null])
+          .with(3, () => [1, 2])
+          .with(__, () => [null, null])
+          .exhaustive();
+
+      type o3 = Expect<Equal<ReturnType<typeof f3>, (number | null)[]>>;
+    });
+
+    it('if the current inferred output is assignable to the new output, just pick the broader one', () => {
+      const f1 = (input: number) =>
+        match(input)
+          .with(1, () => [1, 2])
+          .with(__, () => [1, 2, null])
+          .exhaustive();
+
+      type o1 = Expect<Equal<ReturnType<typeof f1>, (number | null)[]>>;
+    });
+
+    it('It should still be possible specify a precise output type', () => {
+      const f1 = (input: number) =>
+        match<number, State>(input)
+          .with(__, () => ({ status: 'idle' }))
+          // @ts-expect-error
+          .with(1, () => [1, 2])
+          // @ts-expect-error
+          .with(__, () => [1, 2, null])
+          .exhaustive();
+
+      type o1 = Expect<Equal<ReturnType<typeof f1>, State>>;
+    });
+  });
+
+  describe('run', () => {
+    it('should return a single type if they are all compatible', () => {
+      const f = (input: number) =>
+        match(input)
+          .with(1, () => 'ok')
+          .with(2, () => 'test')
+          .with(__, () => 'hello')
+          .run();
+
+      type o1 = Expect<Equal<ReturnType<typeof f>, string>>;
+
+      const f2 = (input: number) =>
+        match(input)
+          .with(1, () => ({ x: 'ok' }))
+          .with(2, () => ({ x: 'test' }))
+          .with(__, () => ({ x: 'hello' }))
+          .run();
+
+      type o2 = Expect<Equal<ReturnType<typeof f2>, { x: string }>>;
+
+      const f3 = (input: number) =>
+        match(input)
+          .with(1, () => [1, 2, null])
+          .with(3, () => [1, 2])
+          .with(__, () => [null, null])
+          .run();
+
+      type o3 = Expect<Equal<ReturnType<typeof f3>, (number | null)[]>>;
+    });
+
+    it('if the current inferred output is assignable to the new output, just pick the broader one', () => {
+      const f1 = (input: number) =>
+        match(input)
+          .with(1, () => [1, 2])
+          .with(__, () => [1, 2, null])
+          .run();
+
+      type o1 = Expect<Equal<ReturnType<typeof f1>, (number | null)[]>>;
+    });
+
+    it('It should still be possible specify a precise output type', () => {
+      const f1 = (input: number) =>
+        match<number, State>(input)
+          .with(__, () => ({ status: 'idle' }))
+          // @ts-expect-error
+          .with(1, () => [1, 2])
+          // @ts-expect-error
+          .with(__, () => [1, 2, null])
+          .run();
+
+      type o1 = Expect<Equal<ReturnType<typeof f1>, State>>;
+    });
+  });
+
+  describe('otherwise', () => {
+    it('should return a single type if they are all compatible', () => {
+      const f = (input: number) =>
+        match(input)
+          .with(1, () => 'ok')
+          .with(2, () => 'test')
+          .with(__, () => 'hello')
+          .otherwise(() => '');
+
+      type o1 = Expect<Equal<ReturnType<typeof f>, string>>;
+
+      const f2 = (input: number) =>
+        match(input)
+          .with(1, () => ({ x: 'ok' }))
+          .with(2, () => ({ x: 'test' }))
+          .with(__, () => ({ x: 'hello' }))
+          .otherwise(() => ({ x: '' }));
+
+      type o2 = Expect<Equal<ReturnType<typeof f2>, { x: string }>>;
+
+      const f3 = (input: number) =>
+        match(input)
+          .with(1, () => [1, 2, null])
+          .with(3, () => [1, 2])
+          .with(__, () => [null, null])
+          .otherwise(() => [0]);
+
+      type o3 = Expect<Equal<ReturnType<typeof f3>, (number | null)[]>>;
+    });
+
+    it('if the current inferred output is assignable to the new output, just pick the broader one', () => {
+      const f1 = (input: number) =>
+        match(input)
+          .with(1, () => [1, 2])
+          .with(__, () => [1, 2, null])
+          .otherwise(() => [0]);
+
+      type o1 = Expect<Equal<ReturnType<typeof f1>, (number | null)[]>>;
+    });
+
+    it('It should still be possible specify a precise output type', () => {
+      const f1 = (input: number) =>
+        match<number, State>(input)
+          .with(__, () => ({ status: 'idle' }))
+          // @ts-expect-error
+          .with(1, () => [1, 2])
+          // @ts-expect-error
+          .with(__, () => [1, 2, null])
+          .otherwise(() => ({ status: 'idle' }));
+
+      type o1 = Expect<Equal<ReturnType<typeof f1>, State>>;
+    });
+  });
+});


### PR DESCRIPTION
## Improve output type inference

the output type of a match expressions will now be inferred as the Union of the return types of all branches:

```ts
const output = match(x as number)
  .with(1, () => "string")
  .with(2, () => 20) // this used to raise a compilation error, because we were expecting that all branches had the same type
  .with(__, () => true)
  .exhaustive();
  
type T = typeof output // string | number | boolean
```