### PR TITLE
Unit Patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,10 +666,12 @@ console.log(output);
 The `__.unit` pattern will match any value of type `null` or `undefined`.
 
 You will **not often need this wildcard** as ordinarily `null` and `undefined`
-are their own wildcards. However, sometimes `null` and `undefined`
-appear in a union together and you may want to treat them as equivalent. This is
-not the cases in many contexts, but if they do appear together in a union and you
-do want to treat them as equivalent then this may come in handy.
+are their own wildcards. 
+
+However, sometimes `null` and `undefined` appear in a union together 
+(e.g. `null | undefined | string`) and you may want to treat them as equivalent.
+This is often not the case in many contexts. However, if they do appear together 
+in a union and you do want to treat them as equivalent then this may come in handy.
 
 ```ts
 import { match, __ } from 'ts-pattern';

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ yarn add ts-pattern
     - [`__.string` wildcard](#__string-wildcard)
     - [`__.number` wildcard](#__number-wildcard)
     - [`__.boolean` wildcard](#__boolean-wildcard)
+    - [`__.unit` wildcard](#__unit-wildcard)
     - [Objects](#objects)
     - [Lists (arrays)](#lists-arrays)
     - [Tuples (arrays)](#tuples-arrays)
@@ -658,6 +659,34 @@ const output = match<number | string | boolean>(input)
 
 console.log(output);
 // => 'it is a boolean!'
+```
+
+#### `__.unit` wildcard
+
+The `__.unit` pattern will match any value of type `null` or `undefined`.
+
+You will **not often need this wildcard** as ordinarily `null` and `undefined`
+are their own wildcards. However, sometimes `null` and `undefined`
+appear in a union together and you may want to treat them as equivalent. This is
+not the cases in many contexts, but if they do appear together in a union and you
+do want to treat them as equivalent then this may come in handy.
+
+```ts
+import { match, __ } from 'ts-pattern';
+
+const input = null;
+
+const output = match<number | string | boolean | null | undefined>(input)
+  .with(__.string, () => 'it is a string!')
+  .with(__.number, () => 'it is a number!')
+  .with(__.boolean, () => 'it is a boolean!')
+  .with(__.unit, () => 'it is either null or undefined!')
+  .with(null, () => 'it is null!')
+  .with(undefined, () => 'it is undefined!')
+  .run();
+
+console.log(output);
+// => 'it is either null or undefined!'
 ```
 
 #### Objects

--- a/src/PatternType.ts
+++ b/src/PatternType.ts
@@ -2,6 +2,7 @@ export enum PatternType {
   String = '@ts-pattern/string',
   Number = '@ts-pattern/number',
   Boolean = '@ts-pattern/boolean',
+  Unit = '@ts-pattern/unit',
   Guard = '@ts-pattern/guard',
   Not = '@ts-pattern/not',
   NamedSelect = '@ts-pattern/named-select',
@@ -28,4 +29,5 @@ export const __ = {
   string: PatternType.String,
   number: PatternType.Number,
   boolean: PatternType.Boolean,
+  unit: PatternType.Unit,
 } as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -297,6 +297,9 @@ const matchPattern = <a, p extends Pattern<a>>(
     if (pattern === __.number) {
       return typeof value === 'number' && !Number.isNaN(value);
     }
+    if (pattern === __.unit) {
+      return value === undefined || value === null;
+    }
   }
 
   return value === pattern;

--- a/src/types/InvertPattern.ts
+++ b/src/types/InvertPattern.ts
@@ -18,6 +18,8 @@ export type InvertPattern<p> = p extends typeof __.number
   ? string
   : p extends typeof __.boolean
   ? boolean
+  : p extends typeof __.unit
+  ? null | undefined
   : p extends NamedSelectPattern<any> | AnonymousSelectPattern | typeof __
   ? unknown
   : p extends GuardPattern<infer p1, infer p2>
@@ -68,6 +70,8 @@ export type InvertPatternForExclude<p, i> = p extends NotPattern<infer p1>
   ? string
   : p extends typeof __.boolean
   ? boolean
+  : p extends typeof __.unit
+  ? null | undefined
   : p extends NamedSelectPattern<any> | AnonymousSelectPattern | typeof __
   ? unknown
   : p extends GuardPattern<any, infer p1>

--- a/src/types/Pattern.ts
+++ b/src/types/Pattern.ts
@@ -51,6 +51,8 @@ type WildCardPattern<a> = a extends number
   ? typeof __.string
   : a extends boolean
   ? typeof __.boolean
+  : a extends null | undefined
+  ? typeof __.unit
   : never;
 
 /**

--- a/tests/not.test.ts
+++ b/tests/not.test.ts
@@ -14,6 +14,10 @@ describe('not', () => {
             type t = Expect<Equal<typeof x, unknown>>;
             return 'not a string';
           })
+          .with(not(__.unit), (x) => {
+            type t = Expect<Equal<typeof x, unknown>>;
+            return 'not a unit type';
+          })
           .run();
 
       expect(get(20)).toEqual('not a string');
@@ -96,6 +100,24 @@ describe('not', () => {
         match<{ str: string }>({ str: 'hello' })
           .with(not(untypedNullable), ({ str }) => str)
           // @ts-expect-error
+          .exhaustive()
+      ).toBe('hello');
+    });
+
+    it('should correctly exclude unit types with the unit wildcard', () => {
+      expect(
+        match<{ str: string | null | undefined }>({ str: 'hello' })
+          .with({ str: not(__.unit) }, ({ str }) => {
+            type t = Expect<Equal<typeof str, string>>;
+
+            return str;
+          })
+          .with({ str: __.unit }, ({ str }) => {
+            type t = Expect<Equal<typeof str, null | undefined>>;
+
+            return null;
+          })
+
           .exhaustive()
       ).toBe('hello');
     });

--- a/tests/wildcards.test.ts
+++ b/tests/wildcards.test.ts
@@ -4,7 +4,7 @@ import { Blog } from './utils';
 
 describe('wildcards', () => {
   it('should match String wildcards', () => {
-    const res = match<string | number | boolean>('')
+    const res = match<string | number | boolean | null | undefined>('')
       .with(__.string, (x) => {
         type t = Expect<Equal<typeof x, string>>;
         return true;
@@ -15,7 +15,7 @@ describe('wildcards', () => {
   });
 
   it('should match Number wildcards', () => {
-    const res = match<string | number | boolean>(2)
+    const res = match<string | number | boolean | null | undefined>(2)
       .with(__.number, (x) => {
         type t = Expect<Equal<typeof x, number>>;
         return true;
@@ -26,7 +26,7 @@ describe('wildcards', () => {
   });
 
   it('should match Boolean wildcards', () => {
-    const res = match<string | number | boolean>(true)
+    const res = match<string | number | boolean | null | undefined>(true)
       .with(__.boolean, (x) => {
         type t = Expect<Equal<typeof x, boolean>>;
         return true;
@@ -34,6 +34,25 @@ describe('wildcards', () => {
       .otherwise(() => false);
 
     expect(res).toEqual(true);
+  });
+
+  it('should match Unit wildcards', () => {
+    const res = match<string | number | boolean | null | undefined>(null)
+      .with(__.unit, (x) => {
+        type t = Expect<Equal<typeof x, null | undefined>>;
+        return true;
+      })
+      .otherwise(() => false);
+
+    const res2 = match<string | number | boolean | null | undefined>(undefined)
+      .with(__.unit, (x) => {
+        type t = Expect<Equal<typeof x, null | undefined>>;
+        return true;
+      })
+      .otherwise(() => false);
+
+    expect(res).toEqual(true);
+    expect(res2).toEqual(true);
   });
 
   it('should match String, Number and Boolean wildcards', () => {


### PR DESCRIPTION
So I've brought this up as desirable in #29 and I didn't detect too much enthusiasm, but I thought to make a PR anyway. 

This PR adds a new wildcard pattern called `__.unit`. Its purpose is to match against both of javascript's unit types, `null` and `undefined`. As they are unit types `undefined` and `null` are their own wildcards, but at least in my codebases its very common for them to appear in a union together. For example in graphql-codgen output its very very common to have codegen like this:

```ts
interface Foo {
  __typename: "Foo";
  value?: string | null;
}
```

These kinds of types make it very annoying to match against, esp when they are more complicated than this example and occur in large discriminated unions. For my purposes `undefined` and `null` are equivalent, and having a built in wildcard for both of them could simplify a lot of my patterns.

It seemed quite easy to implement, but I'm sure I haven't got enough tests (esp of the type level variety). But I would like some feedback about whether you find this addition desirable or problematic.

### Example usage:

```ts
import { match, not, __ } from 'ts-pattern';

interface Foo {
  __typename: "Foo";
  value?: string | null;
}

declare const foo: Foo;

match(foo)
  .with({value: __.unit, () => {
    console.log('is a unit type');
  })
  .with({value: not(__.unit)}, ({value}) => {
    console.log(`is a string, ${value.toLowerCase()}`)
  })
  .exhaustive()
```