### PR TITLE
Pass matched value to otherwise

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,10 +354,10 @@ You can use it at the top level, or inside your pattern.
 
 Note that exhaustive pattern matching is **optional**. It comes with the trade-off of having **longer compilation times** because the type checker has more work to do.
 
-Alternatively you can use `.otherwise()`, which take an handler returning a default value. `.otherwise(handler)` is equivalent to `.with(__, handler).exhaustive()`.
+Alternatively you can use `.otherwise()`, which take an handler which is given as argument the value that has not mached other clauses, and returns a value. `.otherwise(handler)` is equivalent to `.with(__, handler).exhaustive()`.
 
 ```ts
-  .otherwise(() => state);
+  .otherwise(value => state);
 ```
 
 If you don't want to use `.exhaustive()` and also don't want to provide a default value with `.otherwise()`, you can use `.run()` instead:

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,7 @@ const builder = <a, b>(
       ),
 
     otherwise: <c>(
-      handler: () => PickReturnValue<b, c>
+      handler: (value: a) => PickReturnValue<b, c>
     ): PickReturnValue<b, c> =>
       builder<a, PickReturnValue<b, c>>(
         value,

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -122,7 +122,7 @@ export type Match<
    * Equivalent to `.with(__, () => x).run()`
    **/
   otherwise: <c>(
-    handler: () => PickReturnValue<o, c>
+    handler: (value: i) => PickReturnValue<o, c>
   ) => PickReturnValue<o, Union<inferredOutput, c>>;
 
   /**

--- a/tests/otherwise.test.ts
+++ b/tests/otherwise.test.ts
@@ -1,0 +1,10 @@
+import { match, __ } from '../src';
+
+describe('otherwise', () => {
+    it('should pass matched value to otherwise', () => {
+        const result = match(42)
+            .with(51, d => d)
+            .otherwise(d => d);
+        expect(result).toBe(42);
+    })
+});


### PR DESCRIPTION
Hi !

Wouldnt it be relevant to pass the matched value to the `.otherwise()` handler ?

before:
```typescript
const value = computeValue();
const result = match(value)
        .when(a, d => d * 2)
        .when(b, d => d / 2)
        .otherwise(() => value + 2);
```

after:
```typescript
const result = match(computeValue())
        .when(a, d => d * 2)
        .when(b, d => d / 2)
        .otherwise(d => d + 2);
```

