### PR TITLE
Exhaustive fallback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,21 @@ const builder = <a, b>(
         ])
       ).run(),
 
-    exhaustive: () => run(),
+    exhaustive: <c>(handler?: (notMatchedValue: unknown) => c) => {
+      if (!handler) {
+        return run();
+      }
+      return builder<a, PickReturnValue<b, c>>(
+        value,
+        cases.concat([
+          {
+            test: () => true,
+            handler,
+            select: (value) => value,
+          },
+        ])
+      ).run();
+    },
 
     run,
   };

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -137,7 +137,7 @@ export type Match<
    * */
   exhaustive: DeepExcludeAll<i, patternValueTuples> extends infer remainingCases
     ? [remainingCases] extends [never]
-      ? () => PickReturnValue<o, inferredOutput>
+      ? ExhaustiveResult<o, inferredOutput>
       : NonExhaustiveError<remainingCases>
     : never;
 
@@ -152,3 +152,8 @@ type DeepExcludeAll<a, tuple extends [any, any]> = DeepExclude<
   a,
   tuple extends any ? InvertPatternForExclude<tuple[0], tuple[1]> : never
 >;
+
+interface ExhaustiveResult<o, inferredOutput>  {
+  (): PickReturnValue<o, inferredOutput>;
+  <c>(handler: (notMatchedValue: unknown) => c): PickReturnValue<o, Union<inferredOutput, c>>;
+}

--- a/tests/exhaustive-match.test.ts
+++ b/tests/exhaustive-match.test.ts
@@ -868,4 +868,21 @@ describe('exhaustive()', () => {
         .with({ t: 'b' }, (x) => 'ok')
         .exhaustive();
   });
+
+
+  it('accepts fallback to exhaustive', () => {
+
+    const input: 'a' | 'b' = 'c' as any;
+    const value = match(input)
+      .with('a', x => x)
+      .with('b', x => x)
+      .exhaustive(v => ['unexpected', v] as const);
+
+    // check return type
+    const shoulBe: readonly ['unexpected', unknown] | 'a' | 'b' = value;
+    // @ts-expect-error
+    const shouldNotBe: 'a' | 'b' = value;
+
+    expect(value).toStrictEqual(['unexpected', 'c']);
+  });
 });


### PR DESCRIPTION
Hi !

Consider the following dummy case:

```typescript
const value = fs.readFileSync('some-file', 'utf8') as AorB;

const value = match(value)
    .with('a', () => 'something')
    .with('b', () => 'other thing')
    .exhaustive();
```

Currently, `.exhaustive()`  checks that you handled every possible type, but does not provide any mechanism other than throwing an exception if the actual runtime value does not conform to this type. Nor any way to customize the thrown exception.

Those are things i'd like to be able to do:

```typescript
// throw a custom exception
.exhaustive(() => {throw new Error('Your configuration file is corrupted')});

// return a default value
.exhaustive(v => {
     console.warn('The config file is corrupted, found value : ' + v);
     return defaultConfig;
});
```

The main difference here compared to `.otherwise()` it that it still checks that every valid case declared in types has been covered, while providing the graceful fallback that `.otherwise()` provides.

(I know I could count on libs like Joi to handle data validation, but that I think that would be largely overkill and redundant)

What do you think ?