### PR TITLE
selectOr functionality

### DIFF
--- a/src/guards.ts
+++ b/src/guards.ts
@@ -1,9 +1,11 @@
 import * as symbols from './symbols';
 import {
   AnonymousSelectPattern,
+  AnonymousSelectOrPattern,
   GuardFunction,
   GuardPattern,
   NamedSelectPattern,
+  NamedSelectOrPattern,
   NotPattern,
   Pattern,
 } from './types/Pattern';
@@ -34,6 +36,27 @@ export function select<k extends string>(
     : {
         [symbols.PatternKind]: symbols.NamedSelect,
         [symbols.NamedSelect]: key,
+      };
+}
+
+export function selectOr<r>(defaultValue: r): AnonymousSelectOrPattern<r>;
+export function selectOr<r, k extends string>(
+  defaultValue: r,
+  key: k
+): NamedSelectOrPattern<r, k>;
+export function selectOr<r, k extends string>(
+  defaultValue: r,
+  key?: k
+): AnonymousSelectOrPattern<r> | NamedSelectOrPattern<r, k> {
+  return key === undefined
+    ? {
+        [symbols.PatternKind]: symbols.AnonymousSelectOr,
+        [symbols.DefaultValue]: defaultValue,
+      }
+    : {
+        [symbols.PatternKind]: symbols.NamedSelectOr,
+        [symbols.NamedSelect]: key,
+        [symbols.DefaultValue]: defaultValue,
       };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,12 +199,12 @@ const matchPattern = <i, p extends Pattern<i>>(
     if (isGuardPattern(pattern)) return Boolean(pattern[symbols.Guard](value));
 
     if (isNamedSelectPattern(pattern)) {
-      select(pattern[symbols.NamedSelect], value);
+      select(pattern[symbols.NamedSelect], value === symbols.None ? undefined : value);
       return true;
     }
 
     if (isAnonymousSelectPattern(pattern)) {
-      select(ANONYMOUS_SELECT_KEY, value);
+      select(ANONYMOUS_SELECT_KEY, value === symbols.None ? undefined : value);
       return true;
     }
 

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -32,3 +32,19 @@ export type NamedSelect = typeof NamedSelect;
 /** @internal This symbol should only be used by ts-pattern's internals. */
 export const AnonymousSelect = Symbol('@ts-pattern/anonymous-select');
 export type AnonymousSelect = typeof AnonymousSelect;
+
+/** @internal This symbol should only be used by ts-pattern's internals. */
+export const DefaultValue = Symbol('@ts-pattern/default-value');
+export type DefaultValue = typeof DefaultValue;
+
+/** @internal This symbol should only be used by ts-pattern's internals. */
+export const NamedSelectOr = Symbol('@ts-pattern/named-select-or');
+export type NamedSelectOr = typeof NamedSelectOr;
+
+/** @internal This symbol should only be used by ts-pattern's internals. */
+export const AnonymousSelectOr = Symbol('@ts-pattern/anonymous-select-or');
+export type AnonymousSelectOr = typeof AnonymousSelectOr;
+
+/** @internal This symbol should only be used by ts-pattern's internals. */
+export const None = Symbol('@ts-pattern/none');
+export type None = typeof None;

--- a/src/types/FindSelected.ts
+++ b/src/types/FindSelected.ts
@@ -1,13 +1,22 @@
 import type * as symbols from '../symbols';
 import type { Cast, IsPlainObject, UnionToIntersection } from './helpers';
-import type { NamedSelectPattern, AnonymousSelectPattern } from './Pattern';
+import type {
+  NamedSelectPattern,
+  AnonymousSelectPattern,
+  NamedSelectOrPattern,
+  AnonymousSelectOrPattern,
+} from './Pattern';
 
 export type FindSelectionUnion<
   i,
   p,
   // path just serves as an id, to identify different anonymous patterns which have the same type
   path extends any[] = []
-> = p extends NamedSelectPattern<infer k>
+> = p extends NamedSelectOrPattern<infer r, infer k>
+  ? FindSelectionUnion<r, NamedSelectPattern<k>, path>
+  : p extends AnonymousSelectOrPattern<infer r>
+  ? FindSelectionUnion<r, AnonymousSelectPattern, path>
+  : p extends NamedSelectPattern<infer k>
   ? { [kk in k]: [i, path] }
   : p extends AnonymousSelectPattern
   ? { [kk in symbols.AnonymousSelect]: [i, path] }

--- a/src/types/InvertPattern.ts
+++ b/src/types/InvertPattern.ts
@@ -4,6 +4,8 @@ import type {
   AnonymousSelectPattern,
   GuardPattern,
   NotPattern,
+  NamedSelectOrPattern,
+  AnonymousSelectOrPattern,
 } from './Pattern';
 
 /**
@@ -14,7 +16,9 @@ import type {
 export type InvertPattern<p> = p extends
   | NamedSelectPattern<any>
   | AnonymousSelectPattern
-  ? unknown
+  | NamedSelectOrPattern<infer r, any>
+  | AnonymousSelectOrPattern<infer r>
+  ? r
   : p extends GuardPattern<infer p1, infer p2>
   ? [p2] extends [never]
     ? p1

--- a/src/types/Pattern.ts
+++ b/src/types/Pattern.ts
@@ -43,6 +43,22 @@ export type NamedSelectPattern<k extends string> = {
   [symbols.NamedSelect]: k;
 };
 
+export type AnonymousSelectOrPattern<r> = {
+  /** @internal This property should only be used by ts-pattern's internals. */
+  [symbols.PatternKind]: symbols.AnonymousSelectOr;
+  /** @internal This property should only be used by ts-pattern's internals. */
+  [symbols.DefaultValue]: r;
+};
+
+export type NamedSelectOrPattern<r, k extends string> = {
+  /** @internal This property should only be used by ts-pattern's internals. */
+  [symbols.PatternKind]: symbols.NamedSelectOr;
+  /** @internal This property should only be used by ts-pattern's internals. */
+  [symbols.NamedSelect]: k;
+  /** @internal This property should only be used by ts-pattern's internals. */
+  [symbols.DefaultValue]: r;
+};
+
 /**
  * ### Pattern
  * Patterns can be any (nested) javascript value.
@@ -51,6 +67,8 @@ export type NamedSelectPattern<k extends string> = {
 export type Pattern<a> =
   | AnonymousSelectPattern
   | NamedSelectPattern<string>
+  | AnonymousSelectOrPattern<a>
+  | NamedSelectOrPattern<a, string>
   | GuardPattern<a, a>
   | NotPattern<a | any>
   | (a extends Primitives

--- a/src/wildcards.ts
+++ b/src/wildcards.ts
@@ -1,7 +1,8 @@
 import { when } from './guards';
+import * as symbols from './symbols';
 
 function isUnknown<T>(x: T | unknown): x is unknown {
-  return true;
+  return x !== symbols.None;
 }
 
 function isNumber<T>(x: T | number): x is number {

--- a/tests/selectOr.test.ts
+++ b/tests/selectOr.test.ts
@@ -1,0 +1,187 @@
+import { Expect, Equal } from '../src/types/helpers';
+import { match, __, selectOr, not } from '../src';
+import { State, Event } from './utils';
+import {
+  MixedNamedAndAnonymousSelectError,
+  SeveralAnonymousSelectError,
+} from '../src/types/FindSelected';
+
+describe('select', () => {
+  it('should work with array', () => {
+    expect(
+      match<unknown, string[]>([undefined, undefined])
+        .with([selectOr('hello', 'texts')], ({ texts }, xs) => {
+          type t = Expect<Equal<typeof xs, string[]>>;
+          type t2 = Expect<Equal<typeof texts, string[]>>;
+          return texts;
+        })
+        .run()
+    ).toEqual(['hello', 'hello']);
+
+    expect(
+      match<unknown, string[]>([])
+        .with([selectOr('hello', 'texts')], ({ texts }, xs) => {
+          type t = Expect<Equal<typeof xs, string[]>>;
+          type t2 = Expect<Equal<typeof texts, string[]>>;
+          return texts;
+        })
+        .run()
+    ).toEqual(undefined);
+
+    expect(
+      match<unknown, string[]>([{}, {}])
+        .with([{ text: selectOr('hello', 'texts') }], ({ texts }, xs) => {
+          type t = Expect<Equal<typeof xs, { text: string }[]>>;
+          type t2 = Expect<Equal<typeof texts, string[]>>;
+          return texts;
+        })
+        .run()
+    ).toEqual(['hello', 'hello']);
+
+    expect(
+      match<unknown, string[]>([{}, {}])
+        .with(
+          [{ text: { content: selectOr('hello', 'texts') } }],
+          ({ texts }, xs) => {
+            type t = Expect<Equal<typeof texts, string[]>>;
+            return texts;
+          }
+        )
+        .run()
+    ).toEqual(['hello', 'hello']);
+  });
+
+  it('should work with objects', () => {
+    expect(
+      match<unknown, string>({ status: 'success' })
+        .with(
+          {
+            status: 'success',
+            data: selectOr('some data', 'data'),
+            other: selectOr(20, 'other'),
+          },
+          ({ data, other }) => {
+            type t = Expect<Equal<typeof data, string>>;
+            type t2 = Expect<Equal<typeof other, number>>;
+            return data + other.toString();
+          }
+        )
+        .run()
+    ).toEqual('some data20');
+  });
+
+  it('should work with primitive types', () => {
+    expect(
+      match<unknown, string>(undefined)
+        .with(selectOr('hello', 'x'), ({ x }) => {
+          type t = Expect<Equal<typeof x, string>>;
+          return x;
+        })
+        .run()
+    ).toEqual('hello');
+  });
+
+  it('should work with complex structures', () => {
+    const initState: State = {
+      status: 'idle',
+    } as State;
+
+    const reducer = (state: State, event: Event): State =>
+      match<unknown, State>([state, event])
+        .with(
+          [
+            { status: 'loading' },
+            {
+              type: 'success',
+              data: selectOr('default data', 'data'),
+              requestTime: selectOr(0, 'time'),
+            },
+          ] as const,
+          ({ data, time }) => {
+            type t = Expect<Equal<typeof time, number>>;
+
+            return {
+              status: 'success',
+              data,
+            };
+          }
+        )
+        .with(
+          [
+            { status: 'loading' },
+            { type: 'success', data: selectOr('default data', 'data') },
+          ] as const,
+          ({ data }) => ({
+            status: 'success',
+            data,
+          })
+        )
+        .with(
+          [
+            { status: 'loading' },
+            {
+              type: 'error',
+              error: selectOr(new Error('default error'), 'error'),
+            },
+          ] as const,
+          ({ error }) => ({
+            status: 'error',
+            error,
+          })
+        )
+        .with(
+          [{ status: 'loading' }, { type: 'cancel' }] as const,
+          () => initState
+        )
+        .with([{ status: not('loading') }, { type: 'fetch' }] as const, () => ({
+          status: 'loading',
+        }))
+        .with(
+          [
+            selectOr(initState, 'state'),
+            selectOr({ type: 'cancel' } as Event, 'event'),
+          ] as const,
+          ({ state, event }) => {
+            type t = Expect<Equal<typeof state, State>>;
+            type t2 = Expect<Equal<typeof event, Event>>;
+            return state;
+          }
+        )
+        .run();
+
+    expect(reducer(initState, { type: 'cancel' })).toEqual(initState);
+
+    expect(reducer(initState, { type: 'fetch' })).toEqual({
+      status: 'loading',
+    });
+
+    expect(
+      reducer({ status: 'loading' }, { type: 'success', data: 'yo' })
+    ).toEqual({
+      status: 'success',
+      data: 'yo',
+    });
+
+    expect(reducer({ status: 'loading' }, { type: 'cancel' })).toEqual({
+      status: 'idle',
+    });
+  });
+
+  it('should infer the selection to an error when using several anonymous selection', () => {
+    match({ type: 'point' })
+      .with({ type: 'point', x: selectOr(2), y: selectOr(3) }, (x) => {
+        type t = Expect<Equal<typeof x, SeveralAnonymousSelectError>>;
+        return 'ok';
+      })
+      .run();
+  });
+
+  it('should infer the selection to an error when using mixed named and unnamed selections', () => {
+    match({ type: 'point' })
+      .with({ type: 'point', x: selectOr(2), y: selectOr(3, 'y') }, (x) => {
+        type t = Expect<Equal<typeof x, MixedNamedAndAnonymousSelectError>>;
+        return 'ok';
+      })
+      .run();
+  });
+});


### PR DESCRIPTION
```ts
match({ type: 'point' })
  .with({ type: 'point', x: selectOr(2, 'x'), y: selectOr(3, 'y') }, (point) => {
    point.x // 2
    point.y // 3
  })
  .run();
```

Notable changes:
- Added the `selectOr` selector, which allows for a default value to be passed in case it doesnt exist
- Changed the way patterns traverse objects, now even if the object is missing keys the pattern will go deep into matching, this is in case there's a `selectOr` or `select` deep in the pattern structure, this also means that any pattern with a selector in it will match an object as long as the other conditions are met (if there are any)
- In order to be able to distinguish between objects missing keys and objects with literal `undefined` values a new `symbols.None` constant was added