### PR TITLE
Provide a matcher wildcard for NaN

### DIFF
--- a/src/wildcards.ts
+++ b/src/wildcards.ts
@@ -8,6 +8,10 @@ function isNumber<T>(x: T | number): x is number {
   return typeof x === 'number' && !Number.isNaN(x);
 }
 
+function numberIsNaN<T>(x: T | number): x is number {
+  return Number.isNaN(x);
+}
+
 function isString<T>(x: T | string): x is string {
   return typeof x === 'string';
 }
@@ -23,6 +27,7 @@ function isNullish<T>(x: T | null | undefined): x is null | undefined {
 const unknownGuard = when(isUnknown);
 const stringGuard = when(isString);
 const numberGuard = when(isNumber);
+const NaNGuard = when(numberIsNaN);
 const booleanGuard = when(isBoolean);
 const nullishGuard = when(isNullish);
 
@@ -34,6 +39,8 @@ const nullishGuard = when(isNullish);
  *
  * `__.number` is wildcard pattern matching any **number**.
  *
+ * `__.NaN` is wildcard pattern matching **NaN**
+ *
  * `__.boolean` is wildcard pattern matching any **boolean**.
  *
  * `__.nullish` is wildcard pattern matching **null** or **undefined**.
@@ -42,12 +49,14 @@ const nullishGuard = when(isNullish);
  *   .with(__, () => 'will always match')
  *   .with(__.string, () => 'will match on strings only')
  *   .with(__.number, () => 'will match on numbers only')
+ *   .with(__.NaN, () => 'will match on NaN')
  *   .with(__.boolean, () => 'will match on booleans only')
  *   .with(__.nullish, () => 'will match on null or undefined only')
  */
 export const __ = Object.assign(unknownGuard, {
   string: stringGuard,
   number: numberGuard,
+  NaN: NaNGuard,
   boolean: booleanGuard,
   nullish: nullishGuard,
 });

--- a/tests/numbers.test.ts
+++ b/tests/numbers.test.ts
@@ -18,4 +18,16 @@ describe('Numbers', () => {
 
     expect(res).toEqual(2);
   });
+
+  it('Should match NaN specially', () => {
+    const val: number | null = NaN;
+    const res = match(val)
+      .with(__.nullish, () => 'bad')
+      .with(1, () => 'bad')
+      .with(__.number, () => 'bad')
+      .with(__.NaN, () => 'good')
+      .exhaustive();
+
+    expect(res).toEqual('good');
+  });
 });


### PR DESCRIPTION
`__.number` doesn't match `NaN`, but sometimes you might need to. Because `NaN !== NaN`, this PR adds a matcher function for `NaN`: `__.NaN`.