### PR TITLE
Fix not on anys

### DIFF
--- a/src/types/FindSelected.ts
+++ b/src/types/FindSelected.ts
@@ -1,5 +1,10 @@
 import type * as symbols from '../symbols';
-import type { Cast, IsPlainObject, UnionToIntersection } from './helpers';
+import type {
+  Cast,
+  IsAny,
+  IsPlainObject,
+  UnionToIntersection,
+} from './helpers';
 import type { NamedSelectPattern, AnonymousSelectPattern } from './Pattern';
 
 export type FindSelectionUnion<
@@ -7,7 +12,9 @@ export type FindSelectionUnion<
   p,
   // path just serves as an id, to identify different anonymous patterns which have the same type
   path extends any[] = []
-> = p extends NamedSelectPattern<infer k>
+> = IsAny<i> extends true
+  ? never
+  : p extends NamedSelectPattern<infer k>
   ? { [kk in k]: [i, path] }
   : p extends AnonymousSelectPattern
   ? { [kk in symbols.AnonymousSelect]: [i, path] }

--- a/src/types/FindSelected.ts
+++ b/src/types/FindSelected.ts
@@ -1,10 +1,5 @@
 import type * as symbols from '../symbols';
-import type {
-  Cast,
-  IsAny,
-  IsPlainObject,
-  UnionToIntersection,
-} from './helpers';
+import type { Cast, IsAny, UnionToIntersection } from './helpers';
 import type { NamedSelectPattern, AnonymousSelectPattern } from './Pattern';
 
 export type FindSelectionUnion<
@@ -69,7 +64,7 @@ export type FindSelectionUnion<
         }
       : never
     : never
-  : IsPlainObject<p> extends true
+  : p extends object
   ? i extends object
     ? {
         [k in keyof p]: k extends keyof i

--- a/tests/find-selected.test.ts
+++ b/tests/find-selected.test.ts
@@ -7,6 +7,7 @@ import { Equal, Expect } from '../src/types/helpers';
 import {
   AnonymousSelectPattern,
   NamedSelectPattern,
+  NotPattern,
 } from '../src/types/Pattern';
 import { Event, State } from './utils';
 
@@ -272,6 +273,20 @@ describe('FindSelected', () => {
 
         type cases = [
           Expect<Equal<FindSelected<Input, { type: 'text' }>, Input>>
+        ];
+      });
+
+      it('should return the input type', () => {
+        type Input = { text: any };
+
+        type cases = [
+          Expect<Equal<FindSelected<Input, { text: 'text' }>, Input>>,
+          Expect<
+            Equal<
+              FindSelected<Input, { str: NotPattern<null | undefined> }>,
+              Input
+            >
+          >
         ];
       });
     });

--- a/tests/find-selected.test.ts
+++ b/tests/find-selected.test.ts
@@ -272,19 +272,32 @@ describe('FindSelected', () => {
         type Input = { type: 'text'; text: string; author: { name: string } };
 
         type cases = [
-          Expect<Equal<FindSelected<Input, { type: 'text' }>, Input>>
-        ];
-      });
-
-      it('should return the input type', () => {
-        type Input = { text: any };
-
-        type cases = [
-          Expect<Equal<FindSelected<Input, { text: 'text' }>, Input>>,
+          Expect<Equal<FindSelected<Input, { type: 'text' }>, Input>>,
+          Expect<
+            Equal<FindSelected<{ text: any }, { text: 'text' }>, { text: any }>
+          >,
           Expect<
             Equal<
-              FindSelected<Input, { str: NotPattern<null | undefined> }>,
-              Input
+              FindSelected<
+                { text: any },
+                { str: NotPattern<null | undefined> }
+              >,
+              { text: any }
+            >
+          >,
+          Expect<
+            Equal<
+              FindSelected<{ text: unknown }, { text: 'text' }>,
+              { text: unknown }
+            >
+          >,
+          Expect<
+            Equal<
+              FindSelected<
+                { text: unknown },
+                { str: NotPattern<null | undefined> }
+              >,
+              { text: unknown }
             >
           >
         ];

--- a/tests/nesting.test.ts
+++ b/tests/nesting.test.ts
@@ -75,7 +75,7 @@ describe('Nesting', () => {
       ).toEqual(true);
     });
 
-    it('it should work on 9 level', () => {
+    it('it should work on 7 level', () => {
       expect(
         match({
           one: {
@@ -84,12 +84,8 @@ describe('Nesting', () => {
                 four: {
                   five: {
                     six: {
-                      seven: {
-                        height: {
-                          foo: 2,
-                          bar: true,
-                        },
-                      },
+                      foo: 2,
+                      bar: true,
                     },
                   },
                 },
@@ -105,12 +101,8 @@ describe('Nesting', () => {
                     four: {
                       five: {
                         six: {
-                          seven: {
-                            height: {
-                              foo: __,
-                              bar: select('bar'),
-                            },
-                          },
+                          foo: __,
+                          bar: select('bar'),
                         },
                       },
                     },
@@ -118,7 +110,7 @@ describe('Nesting', () => {
                 },
               },
             },
-            (_, x) => x.one.two.three.four.five.six.seven.height.bar
+            (_, x) => x.one.two.three.four.five.six.bar
           )
           .run()
       ).toEqual(true);
@@ -158,15 +150,15 @@ describe('Nesting', () => {
       ).toEqual(true);
     });
 
-    it('it should work on 11 levels', () => {
+    it('it should work on 9 levels', () => {
       expect(
-        match([[[[[[[[[[{ two: '2', foo: 2, bar: true }]]]]]]]]]])
+        match([[[[[[[[{ two: '2', foo: 2, bar: true }]]]]]]]])
           .with(
-            [[[[[[[[[[{ foo: __, bar: select('bar') }]]]]]]]]]],
+            [[[[[[[[{ foo: __, bar: select('bar') }]]]]]]]],
             ({ bar }) => bar
           )
           .run()
-      ).toEqual([[[[[[[[[[true]]]]]]]]]]);
+      ).toEqual([[[[[[[[true]]]]]]]]);
     });
   });
 });

--- a/tests/not.test.ts
+++ b/tests/not.test.ts
@@ -114,8 +114,18 @@ describe('not', () => {
 
           return null;
         })
-
         .exhaustive()
+    ).toBe('hello');
+  });
+
+  it("shouldn't change a the type if its any or unknown", () => {
+    expect(
+      match<{ str: any }>({ str: 'hello' })
+        .with({ str: not(__.nullish) }, (x) => {
+          type t = Expect<Equal<typeof x, { str: any }>>;
+          return 'hello';
+        })
+        .otherwise(() => 'no')
     ).toBe('hello');
   });
 });


### PR DESCRIPTION
This fixes a bug reported in issue #43 where type inference breaks when matching on something of type `any`.

The tradeoff is that patterns with more than 7 levels of nesting will be considered too deep while it used to be 9. I think that's reasonable. 