### PR TITLE
Add explicit package.json export

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "source": "src/index.ts",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "import": {
         "types": "./dist/index.d.ts",


### PR DESCRIPTION
Hi 👋

This fixes https://github.com/nodejs/node/issues/33460
Without it, it breaks `require.resolve`, used by a lot of tooling (Rollup, React native CLI, etc)