### PR TITLE
[WIP] Variadic tuple support

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,10 +15,6 @@ const reverse = <T>(xs: T[]): T[] => {
 match(xs)
   .with([P.any, ...P.array()], (xs: [unknown, ...unknown[]]) => [])
   .with([42, ...P.array(P.number), '!'], (xs: [42, ...number[], '!']) => [])
-  .with(
-    [...P.array(P.number), ...P.array(P.string)],
-    (xs: [...number[], ...string[]]) => []
-  )
   .otherwise(() => []);
 ```
 

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -80,15 +80,16 @@ type Elem<xs> = xs extends Array<infer x> ? x : never;
  *  match(value)
  *   .with({ users: P.array({ name: P.string }) }, () => 'will match { name: string }[]')
  */
-export function array<input>(): ArrayP<input, unknown>;
+export function array<input>(): ArrayP<input, unknown> &
+  Iterable<ArrayP<input, unknown>>;
 export function array<
   input,
   p extends unknown extends input ? UnknownPattern : Pattern<Elem<input>>
->(pattern: p): ArrayP<input, p>;
+>(pattern: p): ArrayP<input, p> & Iterable<ArrayP<input, p>>;
 export function array<
   input,
   p extends unknown extends input ? UnknownPattern : Pattern<Elem<input>>
->(pattern?: p): ArrayP<input, p> {
+>(pattern?: p): ArrayP<input, p> & Iterable<ArrayP<input, p>> {
   return {
     [symbols.matcher]() {
       return {

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -80,10 +80,15 @@ type Elem<xs> = xs extends Array<infer x> ? x : never;
  *  match(value)
  *   .with({ users: P.array({ name: P.string }) }, () => 'will match { name: string }[]')
  */
+export function array<input>(): ArrayP<input, unknown>;
 export function array<
   input,
   p extends unknown extends input ? UnknownPattern : Pattern<Elem<input>>
->(pattern: p): ArrayP<input, p> {
+>(pattern: p): ArrayP<input, p>;
+export function array<
+  input,
+  p extends unknown extends input ? UnknownPattern : Pattern<Elem<input>>
+>(pattern?: p): ArrayP<input, p> {
   return {
     [symbols.matcher]() {
       return {
@@ -111,6 +116,9 @@ export function array<
         },
         getSelectionKeys: () => getSelectionKeys(pattern),
       };
+    },
+    *[Symbol.iterator]() {
+      yield pattern ? array(pattern) : array();
     },
   };
 }

--- a/src/types/DistributeUnions.ts
+++ b/src/types/DistributeUnions.ts
@@ -35,20 +35,20 @@ import { IsMatching } from './IsMatching';
  * type t2 = DistributeMatchingUnions<['a' | 'b', 1 | 2], ['a', unknown]>;
  * // => ['a', 1 | 2] | ['b', 1 | 2]
  */
-export type DistributeMatchingUnions<a, p> = IsAny<a> extends true
+export type DistributeMatchingUnions<a, b> = IsAny<a> extends true
   ? any
-  : BuildMany<a, Distribute<FindUnionsMany<a, p>>>;
+  : BuildMany<a, Distribute<FindUnionsMany<a, b>>>;
 
 // FindUnionsMany :: a -> Union<a> -> PropertyKey[] -> UnionConfig[]
 export type FindUnionsMany<
   a,
-  p,
+  b,
   path extends PropertyKey[] = []
 > = UnionToTuple<
   (
-    p extends any
-      ? IsMatching<a, p> extends true
-        ? FindUnions<a, p, path>
+    b extends any
+      ? IsMatching<a, b> extends true
+        ? FindUnions<a, b, path>
         : []
       : never
   ) extends (infer T)[]
@@ -76,11 +76,11 @@ export type FindUnionsMany<
  */
 export type FindUnions<
   a,
-  p,
+  b,
   path extends PropertyKey[] = []
-> = unknown extends p
+> = unknown extends b
   ? []
-  : IsAny<p> extends true
+  : IsAny<b> extends true
   ? [] // Don't try to find unions after 5 levels
   : Length<path> extends 5
   ? []
@@ -90,59 +90,59 @@ export type FindUnions<
         cases: a extends any
           ? {
               value: a;
-              subUnions: FindUnionsMany<a, p, path>;
+              subUnions: FindUnionsMany<a, b, path>;
             }
           : never;
         path: path;
       }
     ]
-  : [a, p] extends [readonly any[], readonly any[]]
-  ? [a, p] extends [
+  : [a, b] extends [readonly any[], readonly any[]]
+  ? [a, b] extends [
       readonly [infer a1, infer a2, infer a3, infer a4, infer a5],
-      readonly [infer p1, infer p2, infer p3, infer p4, infer p5]
+      readonly [infer b1, infer b2, infer b3, infer b4, infer b5]
     ]
     ? [
-        ...FindUnions<a1, p1, [...path, 0]>,
-        ...FindUnions<a2, p2, [...path, 1]>,
-        ...FindUnions<a3, p3, [...path, 2]>,
-        ...FindUnions<a4, p4, [...path, 3]>,
-        ...FindUnions<a5, p5, [...path, 4]>
+        ...FindUnions<a1, b1, [...path, 0]>,
+        ...FindUnions<a2, b2, [...path, 1]>,
+        ...FindUnions<a3, b3, [...path, 2]>,
+        ...FindUnions<a4, b4, [...path, 3]>,
+        ...FindUnions<a5, b5, [...path, 4]>
       ]
-    : [a, p] extends [
+    : [a, b] extends [
         readonly [infer a1, infer a2, infer a3, infer a4],
-        readonly [infer p1, infer p2, infer p3, infer p4]
+        readonly [infer b1, infer b2, infer b3, infer b4]
       ]
     ? [
-        ...FindUnions<a1, p1, [...path, 0]>,
-        ...FindUnions<a2, p2, [...path, 1]>,
-        ...FindUnions<a3, p3, [...path, 2]>,
-        ...FindUnions<a4, p4, [...path, 3]>
+        ...FindUnions<a1, b1, [...path, 0]>,
+        ...FindUnions<a2, b2, [...path, 1]>,
+        ...FindUnions<a3, b3, [...path, 2]>,
+        ...FindUnions<a4, b4, [...path, 3]>
       ]
-    : [a, p] extends [
+    : [a, b] extends [
         readonly [infer a1, infer a2, infer a3],
-        readonly [infer p1, infer p2, infer p3]
+        readonly [infer b1, infer b2, infer b3]
       ]
     ? [
-        ...FindUnions<a1, p1, [...path, 0]>,
-        ...FindUnions<a2, p2, [...path, 1]>,
-        ...FindUnions<a3, p3, [...path, 2]>
+        ...FindUnions<a1, b1, [...path, 0]>,
+        ...FindUnions<a2, b2, [...path, 1]>,
+        ...FindUnions<a3, b3, [...path, 2]>
       ]
-    : [a, p] extends [
+    : [a, b] extends [
         readonly [infer a1, infer a2],
-        readonly [infer p1, infer p2]
+        readonly [infer b1, infer b2]
       ]
-    ? [...FindUnions<a1, p1, [...path, 0]>, ...FindUnions<a2, p2, [...path, 1]>]
-    : [a, p] extends [readonly [infer a1], readonly [infer p1]]
-    ? FindUnions<a1, p1, [...path, 0]>
+    ? [...FindUnions<a1, b1, [...path, 0]>, ...FindUnions<a2, b2, [...path, 1]>]
+    : [a, b] extends [readonly [infer a1], readonly [infer b1]]
+    ? FindUnions<a1, b1, [...path, 0]>
     : []
   : a extends Set<any>
   ? []
   : a extends Map<any, any>
   ? []
-  : [IsPlainObject<a>, IsPlainObject<p>] extends [true, true]
+  : [IsPlainObject<a>, IsPlainObject<b>] extends [true, true]
   ? Flatten<
       Values<{
-        [k in keyof a & keyof p]: FindUnions<a[k], p[k], [...path, k]>;
+        [k in keyof a & keyof b]: FindUnions<a[k], b[k], [...path, k]>;
       }>
     >
   : [];

--- a/src/types/ExtractPreciseValue.ts
+++ b/src/types/ExtractPreciseValue.ts
@@ -19,7 +19,8 @@ export type ExtractPreciseValue<a, b> = unknown extends b
   ? DeepExclude<a, b1>
   : b extends readonly (infer bItem)[]
   ? a extends readonly (infer aItem)[]
-    ? b extends readonly [infer b1, infer b2, infer b3, infer b4, infer b5]
+    ? // Tuples
+      b extends readonly [infer b1, infer b2, infer b3, infer b4, infer b5]
       ? a extends readonly [infer a1, infer a2, infer a3, infer a4, infer a5]
         ? ExcludeObjectIfContainsNever<
             [
@@ -66,7 +67,33 @@ export type ExtractPreciseValue<a, b> = unknown extends b
       ? a extends readonly [infer a1]
         ? ExcludeObjectIfContainsNever<[ExtractPreciseValue<a1, b1>], '0'>
         : LeastUpperBound<a, b>
-      : ExtractPreciseValue<aItem, bItem> extends infer preciseValue
+      : // variadic patterns
+      b extends readonly [infer b1, infer b2, ...(readonly (infer bRest)[])]
+      ? a extends readonly [infer a1, infer a2, ...(readonly (infer aRest)[])]
+        ? [
+            ExtractPreciseValue<a1, b1>,
+            ExtractPreciseValue<a2, b2>,
+            ...ExtractPreciseValue<aRest, bRest>[]
+          ]
+        : LeastUpperBound<a, b>
+      : b extends readonly [infer b1, ...(readonly (infer bRest)[])]
+      ? a extends readonly [infer a1, ...(readonly (infer aRest)[])]
+        ? [ExtractPreciseValue<a1, b1>, ...ExtractPreciseValue<aRest, bRest>[]]
+        : LeastUpperBound<a, b>
+      : b extends readonly [...(readonly (infer bRest)[]), infer b1, infer b2]
+      ? a extends readonly [...(readonly (infer aRest)[]), infer a1, infer a2]
+        ? [
+            ...ExtractPreciseValue<aRest, bRest>[],
+            ExtractPreciseValue<a1, b1>,
+            ExtractPreciseValue<a2, b2>
+          ]
+        : LeastUpperBound<a, b>
+      : b extends readonly [...(readonly (infer bRest)[]), infer b1]
+      ? a extends readonly [...(readonly (infer aRest)[]), infer a1]
+        ? [...ExtractPreciseValue<aRest, bRest>[], ExtractPreciseValue<a1, b1>]
+        : LeastUpperBound<a, b>
+      : // Arrays
+      ExtractPreciseValue<aItem, bItem> extends infer preciseValue
       ? [preciseValue] extends [never]
         ? never
         : preciseValue[]

--- a/src/types/ExtractPreciseValue.ts
+++ b/src/types/ExtractPreciseValue.ts
@@ -68,18 +68,37 @@ export type ExtractPreciseValue<a, b> = unknown extends b
         ? ExcludeObjectIfContainsNever<[ExtractPreciseValue<a1, b1>], '0'>
         : LeastUpperBound<a, b>
       : // variadic patterns
-      b extends readonly [infer b1, infer b2, ...(readonly (infer bRest)[])]
+      b extends readonly [infer b1, ...(readonly (infer bRest)[]), infer b2]
+      ? a extends readonly [infer a1, ...(readonly (infer aRest)[]), infer a2]
+        ? [
+            ExtractPreciseValue<a1, b1>,
+            ...ExtractPreciseValue<aRest, bRest>[],
+            ExtractPreciseValue<a2, b2>
+          ]
+        : [
+            ExtractPreciseValue<aItem, b1>,
+            ...ExtractPreciseValue<aItem, bRest>[],
+            ExtractPreciseValue<aItem, b2>
+          ]
+      : b extends readonly [infer b1, infer b2, ...(readonly (infer bRest)[])]
       ? a extends readonly [infer a1, infer a2, ...(readonly (infer aRest)[])]
         ? [
             ExtractPreciseValue<a1, b1>,
             ExtractPreciseValue<a2, b2>,
             ...ExtractPreciseValue<aRest, bRest>[]
           ]
-        : LeastUpperBound<a, b>
+        : [
+            ExtractPreciseValue<aItem, b1>,
+            ExtractPreciseValue<aItem, b2>,
+            ...ExtractPreciseValue<aItem, bRest>[]
+          ]
       : b extends readonly [infer b1, ...(readonly (infer bRest)[])]
       ? a extends readonly [infer a1, ...(readonly (infer aRest)[])]
         ? [ExtractPreciseValue<a1, b1>, ...ExtractPreciseValue<aRest, bRest>[]]
-        : LeastUpperBound<a, b>
+        : [
+            ExtractPreciseValue<aItem, b1>,
+            ...ExtractPreciseValue<aItem, bRest>[]
+          ]
       : b extends readonly [...(readonly (infer bRest)[]), infer b1, infer b2]
       ? a extends readonly [...(readonly (infer aRest)[]), infer a1, infer a2]
         ? [
@@ -87,11 +106,18 @@ export type ExtractPreciseValue<a, b> = unknown extends b
             ExtractPreciseValue<a1, b1>,
             ExtractPreciseValue<a2, b2>
           ]
-        : LeastUpperBound<a, b>
+        : [
+            ...ExtractPreciseValue<aItem, bRest>[],
+            ExtractPreciseValue<aItem, b1>,
+            ExtractPreciseValue<aItem, b2>
+          ]
       : b extends readonly [...(readonly (infer bRest)[]), infer b1]
       ? a extends readonly [...(readonly (infer aRest)[]), infer a1]
         ? [...ExtractPreciseValue<aRest, bRest>[], ExtractPreciseValue<a1, b1>]
-        : LeastUpperBound<a, b>
+        : [
+            ...ExtractPreciseValue<aItem, bRest>[],
+            ExtractPreciseValue<aItem, b1>
+          ]
       : // Arrays
       ExtractPreciseValue<aItem, bItem> extends infer preciseValue
       ? [preciseValue] extends [never]

--- a/src/types/ExtractPreciseValue.ts
+++ b/src/types/ExtractPreciseValue.ts
@@ -135,7 +135,7 @@ export type ExtractPreciseValue<a, b> = unknown extends b
     : LeastUpperBound<a, b>
   : // We add `Error` to the excludeUnion because
   // We want to consider them like primitive values in this context.
-  IsPlainObject<b, BuiltInObjects | Error> extends true
+  IsPlainObject<b, BuiltInObjects | Error | any[]> extends true
   ? a extends object
     ? a extends b
       ? a

--- a/src/types/FindSelected.ts
+++ b/src/types/FindSelected.ts
@@ -184,14 +184,14 @@ type ConcatSelections<
   a extends SelectionsRecord,
   b extends SelectionsRecord
 > = {
-  // keys both on output and sel
-  [k in keyof a & keyof b]: [a[k][0] | b[k][0], a[k][1] & b[k][1]]; // the path has to be the same
-} & {
-  // keys of a
-  [k in Exclude<keyof a, keyof b>]: a[k];
-} & {
-  // keyso of b
-  [k in Exclude<keyof b, keyof a>]: b[k];
+  [k in keyof a | keyof b]: // keys both on output and sel
+  k extends keyof a & keyof b
+    ? [a[k][0] | b[k][0], a[k][1] & b[k][1]] // the path has to be the same
+    : k extends keyof a
+    ? a[k]
+    : k extends keyof b
+    ? b[k]
+    : never;
 };
 
 type ReduceToRecord<

--- a/src/types/InvertPattern.ts
+++ b/src/types/InvertPattern.ts
@@ -82,26 +82,32 @@ export type InvertPattern<p> = p extends Matcher<
     p extends readonly [...any, ...Matcher<any, any, 'array'>[], ...any]
     ? p extends readonly [
         infer p1,
-        infer p2,
-        ...(readonly Matcher<any, infer subp, 'array'>[])
+        ...(readonly Matcher<any, infer restPattern, 'array'>[]),
+        infer p2
       ]
-      ? [InvertPattern<p1>, InvertPattern<p2>, ...InvertPattern<subp>[]]
+      ? [InvertPattern<p1>, ...InvertPattern<restPattern>[], InvertPattern<p2>]
       : p extends readonly [
           infer p1,
-          ...(readonly Matcher<any, infer subp, 'array'>[])
+          infer p2,
+          ...(readonly Matcher<any, infer restPattern, 'array'>[])
         ]
-      ? [InvertPattern<p1>, ...InvertPattern<subp>[]]
+      ? [InvertPattern<p1>, InvertPattern<p2>, ...InvertPattern<restPattern>[]]
       : p extends readonly [
-          ...(readonly Matcher<any, infer subp, 'array'>[]),
+          infer p1,
+          ...(readonly Matcher<any, infer restPattern, 'array'>[])
+        ]
+      ? [InvertPattern<p1>, ...InvertPattern<restPattern>[]]
+      : p extends readonly [
+          ...(readonly Matcher<any, infer restPattern, 'array'>[]),
           infer p1,
           infer p2
         ]
-      ? [...InvertPattern<subp>[], InvertPattern<p1>, InvertPattern<p2>]
+      ? [...InvertPattern<restPattern>[], InvertPattern<p1>, InvertPattern<p2>]
       : p extends readonly [
-          ...(readonly Matcher<any, infer subp, 'array'>[]),
+          ...(readonly Matcher<any, infer restPattern, 'array'>[]),
           infer p1
         ]
-      ? [...InvertPattern<subp>[], InvertPattern<p1>]
+      ? [...InvertPattern<restPattern>[], InvertPattern<p1>]
       : InvertPattern<pp>[]
     : InvertPattern<pp>[]
   : p extends Map<infer pk, infer pv>

--- a/src/types/IsMatching.ts
+++ b/src/types/IsMatching.ts
@@ -1,79 +1,79 @@
 import { Primitives, IsPlainObject, IsUnion } from './helpers';
 
-export type IsMatching<a, p> = true extends IsUnion<a> | IsUnion<p>
+export type IsMatching<a, b> = true extends IsUnion<a> | IsUnion<b>
   ? true extends (
-      p extends any ? (a extends any ? IsMatching<a, p> : never) : never
+      b extends any ? (a extends any ? IsMatching<a, b> : never) : never
     )
     ? true
     : false
   : // Special case for unknown, because this is the type
   // of the inverted `_` wildcard pattern, which should
   // match everything.
-  unknown extends p
+  unknown extends b
   ? true
-  : p extends Primitives
-  ? p extends a
+  : b extends Primitives
+  ? b extends a
     ? true
     : false
-  : [p, a] extends [readonly any[], readonly any[]]
-  ? [p, a] extends [
-      readonly [infer p1, infer p2, infer p3, infer p4, infer p5],
+  : [b, a] extends [readonly any[], readonly any[]]
+  ? [b, a] extends [
+      readonly [infer b1, infer b2, infer b3, infer b4, infer b5],
       readonly [infer a1, infer a2, infer a3, infer a4, infer a5]
     ]
     ? [
-        IsMatching<a1, p1>,
-        IsMatching<a2, p2>,
-        IsMatching<a3, p3>,
-        IsMatching<a4, p4>,
-        IsMatching<a5, p5>
+        IsMatching<a1, b1>,
+        IsMatching<a2, b2>,
+        IsMatching<a3, b3>,
+        IsMatching<a4, b4>,
+        IsMatching<a5, b5>
       ] extends [true, true, true, true, true]
       ? true
       : false
-    : [p, a] extends [
-        readonly [infer p1, infer p2, infer p3, infer p4],
+    : [b, a] extends [
+        readonly [infer b1, infer b2, infer b3, infer b4],
         readonly [infer a1, infer a2, infer a3, infer a4]
       ]
     ? [
-        IsMatching<a1, p1>,
-        IsMatching<a2, p2>,
-        IsMatching<a3, p3>,
-        IsMatching<a4, p4>
+        IsMatching<a1, b1>,
+        IsMatching<a2, b2>,
+        IsMatching<a3, b3>,
+        IsMatching<a4, b4>
       ] extends [true, true, true, true]
       ? true
       : false
-    : [p, a] extends [
-        readonly [infer p1, infer p2, infer p3],
+    : [b, a] extends [
+        readonly [infer b1, infer b2, infer b3],
         readonly [infer a1, infer a2, infer a3]
       ]
-    ? [IsMatching<a1, p1>, IsMatching<a2, p2>, IsMatching<a3, p3>] extends [
+    ? [IsMatching<a1, b1>, IsMatching<a2, b2>, IsMatching<a3, b3>] extends [
         true,
         true,
         true
       ]
       ? true
       : false
-    : [p, a] extends [
-        readonly [infer p1, infer p2],
+    : [b, a] extends [
+        readonly [infer b1, infer b2],
         readonly [infer a1, infer a2]
       ]
-    ? [IsMatching<a1, p1>, IsMatching<a2, p2>] extends [true, true]
+    ? [IsMatching<a1, b1>, IsMatching<a2, b2>] extends [true, true]
       ? true
       : false
-    : [p, a] extends [readonly [infer p1], readonly [infer a1]]
-    ? IsMatching<a1, p1>
-    : p extends a
+    : [b, a] extends [readonly [infer b1], readonly [infer a1]]
+    ? IsMatching<a1, b1>
+    : b extends a
     ? true
     : false
-  : IsPlainObject<p> extends true
+  : IsPlainObject<b> extends true
   ? true extends ( // `true extends union` means "if some cases of the a union are matching"
       a extends any // loop over the `a` union
-        ? [keyof p & keyof a] extends [never] // if no common keys
+        ? [keyof b & keyof a] extends [never] // if no common keys
           ? false
           : /**
            * Intentionally not using ValueOf, to avoid reaching the
            * 'type instanciation is too deep error'.
            */
-          { [k in keyof p & keyof a]: IsMatching<a[k], p[k]> }[keyof p &
+          { [k in keyof b & keyof a]: IsMatching<a[k], b[k]> }[keyof b &
               keyof a] extends true
           ? true // all values are matching
           : false
@@ -81,6 +81,6 @@ export type IsMatching<a, p> = true extends IsUnion<a> | IsUnion<p>
     )
     ? true
     : false
-  : p extends a
+  : b extends a
   ? true
   : false;

--- a/src/types/Pattern.ts
+++ b/src/types/Pattern.ts
@@ -64,7 +64,8 @@ type UnknownMatcher = Matcher<unknown, unknown, any, any>;
 
 export type OptionalP<input, p> = Matcher<input, p, 'optional'>;
 
-export type ArrayP<input, p> = Matcher<input, p, 'array'>;
+export type ArrayP<input, p> = Matcher<input, p, 'array'> &
+  Iterable<Matcher<input, p, 'array'>>;
 
 export type AndP<input, ps> = Matcher<input, ps, 'and'>;
 
@@ -123,7 +124,10 @@ export type Pattern<a> =
       : a extends readonly (infer i)[]
       ? a extends readonly [any, ...any]
         ? { readonly [index in keyof a]: Pattern<a[index]> }
-        : readonly [] | readonly [Pattern<i>, ...Pattern<i>[]]
+        :
+            | readonly []
+            | readonly [Pattern<i>, ...Pattern<i>[]]
+            | readonly [...Pattern<i>[], Pattern<i>]
       : a extends Map<infer k, infer v>
       ? Map<k, Pattern<v>>
       : a extends Set<infer v>

--- a/src/types/Pattern.ts
+++ b/src/types/Pattern.ts
@@ -64,8 +64,7 @@ type UnknownMatcher = Matcher<unknown, unknown, any, any>;
 
 export type OptionalP<input, p> = Matcher<input, p, 'optional'>;
 
-export type ArrayP<input, p> = Matcher<input, p, 'array'> &
-  Iterable<Matcher<input, p, 'array'>>;
+export type ArrayP<input, p> = Matcher<input, p, 'array'>;
 
 export type AndP<input, ps> = Matcher<input, ps, 'and'>;
 

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -125,8 +125,7 @@ export type BuiltInObjects =
   | Date
   | RegExp
   | Generator
-  | { readonly [Symbol.toStringTag]: string }
-  | any[];
+  | { readonly [Symbol.toStringTag]: string };
 
 export type IsPlainObject<o, excludeUnion = BuiltInObjects> = o extends object
   ? // to excluded branded string types,
@@ -204,3 +203,34 @@ export type GuardValue<fn> = fn extends (value: any) => value is infer b
 export type GuardFunction<input, narrowed> =
   | ((value: input) => value is Cast<narrowed, input>)
   | ((value: input) => boolean);
+
+export type Narrow<T> = T extends
+  | Function
+  | string
+  | number
+  | boolean
+  | bigint
+  | []
+  ? T
+  : { [K in keyof T]: Narrow<T[K]> };
+
+type IsTuple<array> = array extends
+  | readonly [any, ...any]
+  | readonly [...any, any]
+  | readonly []
+  ? true
+  : false;
+
+type ContainVariadic<tuple> = tuple extends readonly [any, ...infer tail]
+  ? IsTuple<tail> extends false
+    ? true
+    : ContainVariadic<tail>
+  : tuple extends readonly [...infer inits, any]
+  ? IsTuple<inits> extends false
+    ? true
+    : ContainVariadic<inits>
+  : false;
+
+export type IsVariadic<array> = IsTuple<array> extends true
+  ? ContainVariadic<array>
+  : false;

--- a/tests/deep-exclude.test.ts
+++ b/tests/deep-exclude.test.ts
@@ -224,6 +224,8 @@ describe('DeepExclude', () => {
         >
       ];
     });
+
+    describe('Variadic tuples', () => {});
   });
 
   describe('List', () => {

--- a/tests/extract-precise-value.test.ts
+++ b/tests/extract-precise-value.test.ts
@@ -210,14 +210,12 @@ describe('ExtractPreciseValue', () => {
   });
 
   it('should work with arrays', () => {
-    type cases = [
-      Expect<
-        Equal<
-          ExtractPreciseValue<boolean | { type: string } | string[], string[]>,
-          string[]
-        >
-      >
-    ];
+    type res1 = ExtractPreciseValue<
+      boolean | { type: string } | string[],
+      string[]
+    >;
+
+    type t1 = Expect<Equal<res1, string[]>>;
   });
 
   describe('Optional properties', () => {
@@ -384,6 +382,52 @@ describe('ExtractPreciseValue', () => {
           >
         >
       ];
+    });
+  });
+
+  describe('variadic patterns', () => {
+    it('[a, ...b[]]', () => {
+      type res1 = ExtractPreciseValue<unknown[], [unknown, ...unknown[]]>;
+      type t1 = Expect<Equal<res1, [unknown, ...unknown[]]>>;
+
+      type res2 = ExtractPreciseValue<unknown[], [number, ...string[]]>;
+      type t2 = Expect<Equal<res2, [number, ...string[]]>>;
+
+      type res3 = ExtractPreciseValue<
+        [string, ...boolean[]],
+        ['a', ...unknown[]]
+      >;
+      type t3 = Expect<Equal<res3, ['a', ...boolean[]]>>;
+    });
+
+    it('[a, b, ...c[]]', () => {
+      type res1 = ExtractPreciseValue<
+        unknown[],
+        [unknown, unknown, ...unknown[]]
+      >;
+      type t1 = Expect<Equal<res1, [unknown, unknown, ...unknown[]]>>;
+
+      type res2 = ExtractPreciseValue<
+        unknown[],
+        [number, boolean, ...string[]]
+      >;
+      type t2 = Expect<Equal<res2, [number, boolean, ...string[]]>>;
+
+      type res3 = ExtractPreciseValue<
+        [string, number, ...boolean[]],
+        ['a', 2, ...unknown[]]
+      >;
+      type t3 = Expect<Equal<res3, ['a', 2, ...boolean[]]>>;
+    });
+
+    it('[...a[], b]', () => {
+      // TODO
+    });
+    it('[...a[], b, c]', () => {
+      // TODO
+    });
+    it('[a, ...b[], c]', () => {
+      // TODO
     });
   });
 });

--- a/tests/extract-precise-value.test.ts
+++ b/tests/extract-precise-value.test.ts
@@ -398,6 +398,12 @@ describe('ExtractPreciseValue', () => {
         ['a', ...unknown[]]
       >;
       type t3 = Expect<Equal<res3, ['a', ...boolean[]]>>;
+
+      type res4 = ExtractPreciseValue<
+        (string | boolean)[],
+        ['a', ...unknown[]]
+      >;
+      type t4 = Expect<Equal<res4, ['a', ...(string | boolean)[]]>>;
     });
 
     it('[a, b, ...c[]]', () => {
@@ -421,13 +427,55 @@ describe('ExtractPreciseValue', () => {
     });
 
     it('[...a[], b]', () => {
-      // TODO
+      type res1 = ExtractPreciseValue<unknown[], [...unknown[], unknown]>;
+      type t1 = Expect<Equal<res1, [...unknown[], unknown]>>;
+
+      type res2 = ExtractPreciseValue<unknown[], [...string[], number]>;
+      type t2 = Expect<Equal<res2, [...string[], number]>>;
+
+      type res3 = ExtractPreciseValue<
+        [...boolean[], string],
+        [...unknown[], 'a']
+      >;
+      type t3 = Expect<Equal<res3, [...boolean[], 'a']>>;
     });
     it('[...a[], b, c]', () => {
-      // TODO
+      type res1 = ExtractPreciseValue<
+        unknown[],
+        [...unknown[], unknown, unknown]
+      >;
+      type t1 = Expect<Equal<res1, [...unknown[], unknown, unknown]>>;
+
+      type res2 = ExtractPreciseValue<
+        unknown[],
+        [...string[], number, boolean]
+      >;
+      type t2 = Expect<Equal<res2, [...string[], number, boolean]>>;
+
+      type res3 = ExtractPreciseValue<
+        [...boolean[], string, boolean],
+        [...unknown[], 'a', true]
+      >;
+      type t3 = Expect<Equal<res3, [...boolean[], 'a', true]>>;
     });
     it('[a, ...b[], c]', () => {
-      // TODO
+      type res1 = ExtractPreciseValue<
+        unknown[],
+        [unknown, ...unknown[], unknown]
+      >;
+      type t1 = Expect<Equal<res1, [unknown, ...unknown[], unknown]>>;
+
+      type res2 = ExtractPreciseValue<
+        unknown[],
+        [number, ...string[], boolean]
+      >;
+      type t2 = Expect<Equal<res2, [number, ...string[], boolean]>>;
+
+      type res3 = ExtractPreciseValue<
+        [string, ...boolean[], number],
+        ['a', ...unknown[], 2]
+      >;
+      type t3 = Expect<Equal<res3, ['a', ...boolean[], 2]>>;
     });
   });
 });

--- a/tests/find-selected.test.ts
+++ b/tests/find-selected.test.ts
@@ -79,20 +79,136 @@ describe('FindSelected', () => {
 
     describe('variadic tuples', () => {
       it('[a, ...b[]]', () => {
-        // TODO
+        type res1 = FindSelected<
+          [State, ...Event[]],
+          [SelectP<'state'>, ...ArrayP<unknown, SelectP<'event'>>[]]
+        >;
+        type test1 = Expect<Equal<res1, { state: State; event: Event[] }>>;
+
+        type res2 = FindSelected<
+          [1, ...number[]],
+          [AnonymousSelectP, ...ArrayP<unknown, unknown>[]]
+        >;
+        type test2 = Expect<Equal<res2, 1>>;
+
+        type res3 = FindSelected<
+          [1, ...number[]],
+          [unknown, ...ArrayP<unknown, AnonymousSelectP>[]]
+        >;
+        type test3 = Expect<Equal<res3, number[]>>;
       });
 
       it('[a, b, ...c[]]', () => {
-        // TODO
+        type res1 = FindSelected<
+          [State, State, ...Event[]],
+          [
+            SelectP<'state'>,
+            SelectP<'state2'>,
+            ...ArrayP<unknown, SelectP<'event'>>[]
+          ]
+        >;
+        type test1 = Expect<
+          Equal<res1, { state: State; state2: State; event: Event[] }>
+        >;
+
+        type res2 = FindSelected<
+          [1, 2, ...number[]],
+          [AnonymousSelectP, unknown, ...ArrayP<unknown, unknown>[]]
+        >;
+        type test2 = Expect<Equal<res2, 1>>;
+
+        type res3 = FindSelected<
+          [1, 2, ...number[]],
+          [unknown, AnonymousSelectP, ...ArrayP<unknown, unknown>[]]
+        >;
+        type test3 = Expect<Equal<res3, 2>>;
+
+        type res4 = FindSelected<
+          [1, 2, ...number[]],
+          [unknown, unknown, ...ArrayP<unknown, AnonymousSelectP>[]]
+        >;
+        type test4 = Expect<Equal<res4, number[]>>;
       });
       it('[...a[], b]', () => {
-        // TODO
+        type res1 = FindSelected<
+          [...Event[], State],
+          [...ArrayP<unknown, SelectP<'event'>>[], SelectP<'state'>]
+        >;
+        type test1 = Expect<Equal<res1, { state: State; event: Event[] }>>;
+
+        type res2 = FindSelected<
+          [...number[], 1],
+          [...ArrayP<unknown, unknown>[], AnonymousSelectP]
+        >;
+        type test2 = Expect<Equal<res2, 1>>;
+
+        type res3 = FindSelected<
+          [...number[], 1],
+          [...ArrayP<unknown, AnonymousSelectP>[], unknown]
+        >;
+        type test3 = Expect<Equal<res3, number[]>>;
       });
       it('[...a[], b, c]', () => {
-        // TODO
+        type res1 = FindSelected<
+          [...Event[], State, State],
+          [
+            ...ArrayP<unknown, SelectP<'event'>>[],
+            SelectP<'state'>,
+            SelectP<'state2'>
+          ]
+        >;
+        type test1 = Expect<
+          Equal<res1, { state: State; state2: State; event: Event[] }>
+        >;
+
+        type res2 = FindSelected<
+          [...number[], 1, 2],
+          [...ArrayP<unknown, unknown>[], AnonymousSelectP, unknown]
+        >;
+        type test2 = Expect<Equal<res2, 1>>;
+
+        type res3 = FindSelected<
+          [...number[], 1, 2],
+          [...ArrayP<unknown, unknown>[], unknown, AnonymousSelectP]
+        >;
+        type test3 = Expect<Equal<res3, 2>>;
+
+        type res4 = FindSelected<
+          [...number[], 1, 2],
+          [...ArrayP<unknown, AnonymousSelectP>[], unknown, unknown]
+        >;
+        type test4 = Expect<Equal<res4, number[]>>;
       });
       it('[a, ...b[], c]', () => {
-        // TODO
+        type res1 = FindSelected<
+          [State, ...Event[], State],
+          [
+            SelectP<'state'>,
+            ...ArrayP<unknown, SelectP<'event'>>[],
+            SelectP<'state2'>
+          ]
+        >;
+        type test1 = Expect<
+          Equal<res1, { state: State; state2: State; event: Event[] }>
+        >;
+
+        type res2 = FindSelected<
+          [1, ...number[], 2],
+          [AnonymousSelectP, ...ArrayP<unknown, unknown>[], unknown]
+        >;
+        type test2 = Expect<Equal<res2, 1>>;
+
+        type res3 = FindSelected<
+          [1, ...number[], 2],
+          [unknown, ...ArrayP<unknown, unknown>[], AnonymousSelectP]
+        >;
+        type test3 = Expect<Equal<res3, 2>>;
+
+        type res4 = FindSelected<
+          [1, ...number[], 2],
+          [unknown, ...ArrayP<unknown, AnonymousSelectP>[], unknown]
+        >;
+        type test4 = Expect<Equal<res4, number[]>>;
       });
     });
 

--- a/tests/find-selected.test.ts
+++ b/tests/find-selected.test.ts
@@ -77,6 +77,25 @@ describe('FindSelected', () => {
       ];
     });
 
+    describe('variadic tuples', () => {
+      it('[a, ...b[]]', () => {
+        // TODO
+      });
+
+      it('[a, b, ...c[]]', () => {
+        // TODO
+      });
+      it('[...a[], b]', () => {
+        // TODO
+      });
+      it('[...a[], b, c]', () => {
+        // TODO
+      });
+      it('[a, ...b[], c]', () => {
+        // TODO
+      });
+    });
+
     it('list selections should be wrapped in arrays', () => {
       type cases = [
         Expect<

--- a/tests/invert-pattern.test.ts
+++ b/tests/invert-pattern.test.ts
@@ -22,19 +22,111 @@ describe('InvertPattern', () => {
       ];
       type inverted2 = InvertPattern<pattern2>;
       type test2 = Expect<Equal<inverted2, [unknown, ...unknown[]]>>;
+
+      type pattern3 = [
+        GuardP<unknown, string>,
+        ...Matcher<any, GuardP<unknown, number>, 'array'>[]
+      ];
+      type inverted3 = InvertPattern<pattern3>;
+      type test3 = Expect<Equal<inverted3, [string, ...number[]]>>;
     });
 
     it('[a, b, ...c[]]', () => {
-      // TODO
+      type pattern1 = [
+        'Hello',
+        7,
+        ...Matcher<any, GuardP<unknown, number>, 'array'>[]
+      ];
+      type inverted1 = InvertPattern<pattern1>;
+      type test1 = Expect<Equal<inverted1, ['Hello', 7, ...number[]]>>;
+
+      type pattern2 = [
+        GuardP<unknown, unknown>,
+        GuardP<unknown, unknown>,
+        ...Matcher<unknown, unknown, 'array'>[]
+      ];
+      type inverted2 = InvertPattern<pattern2>;
+      type test2 = Expect<Equal<inverted2, [unknown, unknown, ...unknown[]]>>;
+
+      type pattern3 = [
+        GuardP<unknown, string>,
+        GuardP<unknown, boolean>,
+        ...Matcher<any, GuardP<unknown, number>, 'array'>[]
+      ];
+      type inverted3 = InvertPattern<pattern3>;
+      type test3 = Expect<Equal<inverted3, [string, boolean, ...number[]]>>;
     });
     it('[...a[], b]', () => {
-      // TODO
+      type pattern1 = [
+        ...Matcher<any, GuardP<unknown, number>, 'array'>[],
+        'Hello'
+      ];
+      type inverted1 = InvertPattern<pattern1>;
+      type test1 = Expect<Equal<inverted1, [...number[], 'Hello']>>;
+
+      type pattern2 = [
+        ...Matcher<unknown, unknown, 'array'>[],
+        GuardP<unknown, unknown>
+      ];
+      type inverted2 = InvertPattern<pattern2>;
+      type test2 = Expect<Equal<inverted2, [...unknown[], unknown]>>;
+
+      type pattern3 = [
+        ...Matcher<any, GuardP<unknown, number>, 'array'>[],
+        GuardP<unknown, string>
+      ];
+      type inverted3 = InvertPattern<pattern3>;
+      type test3 = Expect<Equal<inverted3, [...number[], string]>>;
     });
     it('[...a[], b, c]', () => {
-      // TODO
+      type pattern1 = [
+        ...Matcher<any, GuardP<unknown, number>, 'array'>[],
+        'Hello',
+        7
+      ];
+      type inverted1 = InvertPattern<pattern1>;
+      type test1 = Expect<Equal<inverted1, [...number[], 'Hello', 7]>>;
+
+      type pattern2 = [
+        ...Matcher<unknown, unknown, 'array'>[],
+        GuardP<unknown, unknown>,
+        GuardP<unknown, unknown>
+      ];
+      type inverted2 = InvertPattern<pattern2>;
+      type test2 = Expect<Equal<inverted2, [...unknown[], unknown, unknown]>>;
+
+      type pattern3 = [
+        ...Matcher<any, GuardP<unknown, number>, 'array'>[],
+        GuardP<unknown, string>,
+        GuardP<unknown, boolean>
+      ];
+      type inverted3 = InvertPattern<pattern3>;
+      type test3 = Expect<Equal<inverted3, [...number[], string, boolean]>>;
     });
     it('[a, ...b[], c]', () => {
-      // TODO
+      type pattern1 = [
+        7,
+        ...Matcher<any, GuardP<unknown, number>, 'array'>[],
+        'Hello'
+      ];
+      type inverted1 = InvertPattern<pattern1>;
+      type test1 = Expect<Equal<inverted1, [7, ...number[], 'Hello']>>;
+
+      type pattern2 = [
+        GuardP<unknown, unknown>,
+        ...Matcher<unknown, unknown, 'array'>[],
+        GuardP<unknown, unknown>
+      ];
+      type inverted2 = InvertPattern<pattern2>;
+      type test2 = Expect<Equal<inverted2, [unknown, ...unknown[], unknown]>>;
+
+      type pattern3 = [
+        GuardP<unknown, string>,
+        ...Matcher<any, GuardP<unknown, number>, 'array'>[],
+        GuardP<unknown, boolean>
+      ];
+      type inverted3 = InvertPattern<pattern3>;
+      type test3 = Expect<Equal<inverted3, [string, ...number[], boolean]>>;
     });
   });
 });

--- a/tests/invert-pattern.test.ts
+++ b/tests/invert-pattern.test.ts
@@ -1,6 +1,43 @@
+import { P } from '../src';
 import { Equal, Expect } from '../src/types/helpers';
-import { InvertPatternForExclude } from '../src/types/InvertPattern';
-import { Matcher } from '../src/types/Pattern';
+import {
+  InvertPattern,
+  InvertPatternForExclude,
+} from '../src/types/InvertPattern';
+import { ArrayP, GuardP, Matcher, UnknownPattern } from '../src/types/Pattern';
+
+describe('InvertPattern', () => {
+  describe('variadic tuples', () => {
+    it('[a, ...b[]]', () => {
+      type pattern1 = [
+        'Hello',
+        ...Matcher<any, GuardP<unknown, number>, 'array'>[]
+      ];
+      type inverted1 = InvertPattern<pattern1>;
+      type test1 = Expect<Equal<inverted1, ['Hello', ...number[]]>>;
+
+      type pattern2 = [
+        GuardP<unknown, unknown>,
+        ...Matcher<unknown, unknown, 'array'>[]
+      ];
+      type inverted2 = InvertPattern<pattern2>;
+      type test2 = Expect<Equal<inverted2, [unknown, ...unknown[]]>>;
+    });
+
+    it('[a, b, ...c[]]', () => {
+      // TODO
+    });
+    it('[...a[], b]', () => {
+      // TODO
+    });
+    it('[...a[], b, c]', () => {
+      // TODO
+    });
+    it('[a, ...b[], c]', () => {
+      // TODO
+    });
+  });
+});
 
 describe('InvertPatternForExclude', () => {
   it('should correctly invert type guards', () => {
@@ -117,6 +154,25 @@ describe('InvertPatternForExclude', () => {
           >
         >
       ];
+    });
+  });
+
+  describe('variadic tuples', () => {
+    it('[a, ...b[]]', () => {
+      // TODO
+    });
+
+    it('[a, b, ...c[]]', () => {
+      // TODO
+    });
+    it('[...a[], b]', () => {
+      // TODO
+    });
+    it('[...a[], b, c]', () => {
+      // TODO
+    });
+    it('[a, ...b[], c]', () => {
+      // TODO
     });
   });
 

--- a/tests/type-is-matching.test.ts
+++ b/tests/type-is-matching.test.ts
@@ -212,6 +212,17 @@ describe('IsMatching', () => {
       ];
     });
 
+    it('Variadics', () => {
+      type res1 = IsMatching<('a' | 'b')[], [unknown, ...unknown[]]>;
+      type t1 = Expect<Equal<res1, true>>;
+      type res2 = IsMatching<[number], [unknown, ...unknown[]]>;
+      type t2 = Expect<Equal<res2, true>>;
+      type res3 = IsMatching<[number, number], [unknown, ...unknown[]]>;
+      type t3 = Expect<Equal<res3, true>>;
+      type res4 = IsMatching<[], [unknown, ...unknown[]]>;
+      type t4 = Expect<Equal<res4, false>>;
+    });
+
     it('Sets', () => {
       type cases = [
         Expect<Equal<IsMatching<Set<'a' | 'b'>, Set<'a'>>, true>>,

--- a/tests/variadic-tuples.test.ts
+++ b/tests/variadic-tuples.test.ts
@@ -1,14 +1,135 @@
 import { match, P } from '../src';
+import { Equal, Expect } from '../src/types/helpers';
 
 describe('variadic tuples ([a, ...b[]])', () => {
-  it('', () => {
+  it('unknown input', () => {
     const xs: unknown[] = [1, 2, 3, 'a', 'b', 'c'];
 
     match(xs)
-      .with([P.any, ...P.array()], (xs) => [])
-      .with([...P.array(), 7], (xs) => [])
-      .with([42 as const, ...P.array(P.number)], (xs) => [])
-      .with([42, ...P.array(P.number), '!'] as const, (xs) => [])
+      .with([P.any, ...P.array()], (xs) => {
+        type t = Expect<Equal<typeof xs, [unknown, ...unknown[]]>>;
+        return [];
+      })
+      .with([...P.array(), 7], (xs) => {
+        type t = Expect<Equal<typeof xs, [...unknown[], number]>>;
+        return [];
+      })
+      .with([42 as const, ...P.array(P.number)], (xs) => {
+        type t = Expect<Equal<typeof xs, [42, ...number[]]>>;
+        return [];
+      })
+      .with([42, ...P.array(P.number), '!'] as const, (xs) => {
+        type t = Expect<Equal<typeof xs, [42, ...number[], '!']>>;
+        return [];
+      })
+      .with([1, 2, ...P.array(P.number)] as const, (xs) => {
+        type t = Expect<Equal<typeof xs, [1, 2, ...number[]]>>;
+        return [];
+      })
+      .with([...P.array(P.string), 'a', 'b'] as const, (xs) => {
+        type t = Expect<Equal<typeof xs, [...string[], 'a', 'b']>>;
+        return [];
+      })
+      .otherwise(() => {
+        return [];
+      });
+  });
+
+  it('known input', () => {
+    const xs: (string | number)[] = [1, 2, 3, 'a', 'b', 'c'];
+
+    match(xs)
+      .with([P.any, ...P.array()], (xs) => {
+        type t = Expect<
+          Equal<typeof xs, [string | number, ...(string | number)[]]>
+        >;
+        return [];
+      })
+      .with([...P.array(), 7 as const], (xs) => {
+        type t = Expect<Equal<typeof xs, [...(string | number)[], 7]>>;
+        return [];
+      })
+      .with([42 as const, ...P.array(P.number)], (xs) => {
+        type t = Expect<Equal<typeof xs, [42, ...number[]]>>;
+        return [];
+      })
+      .with([42, ...P.array(P.number), 7] as const, (xs) => {
+        type t = Expect<Equal<typeof xs, [42, ...number[], 7]>>;
+        return [];
+      })
+      .with([1, 2, ...P.array(P.number)] as const, (xs) => {
+        type t = Expect<Equal<typeof xs, [1, 2, ...number[]]>>;
+        return [];
+      })
+      .with([...P.array(P.string), 'a', 'b'] as const, (xs) => {
+        type t = Expect<Equal<typeof xs, [...string[], 'a', 'b']>>;
+        return [];
+      })
+      .otherwise(() => {
+        return [];
+      });
+  });
+
+  it('select', () => {
+    const xs: (string | number)[] = [1, 2, 3, 'a', 'b', 'c'];
+
+    match(xs)
+      .with([P.select(), ...P.array()], (xs) => {
+        type t = Expect<Equal<typeof xs, string | number>>;
+        return [];
+      })
+      .with([...P.array(P.select()), 7], (xs) => {
+        type t = Expect<Equal<typeof xs, (string | number)[]>>;
+        return [];
+      })
+      .with([42 as const, ...P.array(P.select(P.number))], (xs) => {
+        type t = Expect<Equal<typeof xs, number[]>>;
+        return [];
+      })
+      .with([42, ...P.array(P.select(P.number)), '!'] as const, (xs) => {
+        type t = Expect<Equal<typeof xs, number[]>>;
+        return [];
+      })
+      .with([1, 2, ...P.array(P.select(P.number))] as const, (xs) => {
+        type t = Expect<Equal<typeof xs, number[]>>;
+        return [];
+      })
+      .with([...P.array(P.select(P.string)), 'a', 'b'] as const, (xs) => {
+        type t = Expect<Equal<typeof xs, string[]>>;
+        return [];
+      })
+      .with([1, P.select(2), ...P.array(P.number)] as const, (xs) => {
+        type t = Expect<Equal<typeof xs, 2>>;
+        return [];
+      })
+      .with([...P.array(P.string), P.select(2), 'b'] as const, (xs) => {
+        type t = Expect<Equal<typeof xs, 2>>;
+        return [];
+      })
       .otherwise(() => []);
+  });
+
+  describe('exhaustiveness checking', () => {
+    it('catch-all wildcards', () => {
+      const xs: (string | number)[] = [1, 2, 3, 'a', 'b', 'c'];
+
+      match(xs)
+        .with([P.any, ...P.array()], (xs) => {
+          return 'branch 1' as const;
+        })
+        // @ts-expect-error: empty list case missing
+        .exhaustive();
+
+      const res = match(xs)
+        .with([P.any, ...P.array()], (xs) => {
+          return 'branch 1' as const;
+        })
+        .with([], (xs) => {
+          return 'branch 2' as const;
+        })
+        .exhaustive();
+
+      type t = Expect<Equal<typeof res, 'branch 1' | 'branch 2'>>;
+    });
   });
 });

--- a/tests/variadic-tuples.test.ts
+++ b/tests/variadic-tuples.test.ts
@@ -86,31 +86,89 @@ describe('variadic tuples ([a, ...b[]])', () => {
         type t = Expect<Equal<typeof xs, number[]>>;
         return [];
       })
-      .with([42, ...P.array(P.select(P.number)), '!'] as const, (xs) => {
+      .with(
+        [P.select('head', 42 as const), ...P.array(P.select('tail', P.number))],
+        (xs) => {
+          type t = Expect<Equal<typeof xs, { tail: number[]; head: 42 }>>;
+          return [];
+        }
+      )
+      .with([1, 2, ...P.array(P.select(P.number))] as const, (xs) => {
         type t = Expect<Equal<typeof xs, number[]>>;
         return [];
       })
-      .with([1, 2, ...P.array(P.select(P.number))] as const, (xs) => {
-        type t = Expect<Equal<typeof xs, number[]>>;
+      .with(
+        [
+          P.select('a', 1),
+          P.select('b', 2),
+          ...P.array(P.select('c', P.number)),
+        ] as const,
+        (xs) => {
+          type t = Expect<Equal<typeof xs, { c: number[]; a: 1; b: 2 }>>;
+          return [];
+        }
+      )
+      .with([1, P.select(2), ...P.array(P.number)] as const, (xs) => {
+        type t = Expect<Equal<typeof xs, 2>>;
+        return [];
+      })
+      .with([...P.array(P.select(P.string)), 'a'] as const, (xs) => {
+        type t = Expect<Equal<typeof xs, string[]>>;
+        return [];
+      })
+      .with(
+        [
+          ...P.array(P.select('inits', P.string)),
+          P.select('last', 'a'),
+        ] as const,
+        (xs) => {
+          type t = Expect<Equal<typeof xs, { inits: string[]; last: 'a' }>>;
+          return [];
+        }
+      )
+      .with([...P.array(P.string), P.select()] as const, (xs) => {
+        type t = Expect<Equal<typeof xs, string | number>>;
         return [];
       })
       .with([...P.array(P.select(P.string)), 'a', 'b'] as const, (xs) => {
         type t = Expect<Equal<typeof xs, string[]>>;
         return [];
       })
-      .with([1, P.select(2), ...P.array(P.number)] as const, (xs) => {
-        type t = Expect<Equal<typeof xs, 2>>;
-        return [];
-      })
       .with([...P.array(P.string), P.select(2), 'b'] as const, (xs) => {
         type t = Expect<Equal<typeof xs, 2>>;
         return [];
       })
+      .with(
+        [
+          ...P.array(P.select('a', P.string)),
+          P.select('b', 2),
+          P.select('c', 'b'),
+        ] as const,
+        (xs) => {
+          type t = Expect<Equal<typeof xs, { a: string[]; b: 2; c: 'b' }>>;
+          return [];
+        }
+      )
+      .with([42, ...P.array(P.select(P.number)), '!'] as const, (xs) => {
+        type t = Expect<Equal<typeof xs, number[]>>;
+        return [];
+      })
+      .with(
+        [
+          P.select('a', 42),
+          ...P.array(P.select('b', P.number)),
+          P.select('c', '!'),
+        ] as const,
+        (xs) => {
+          type t = Expect<Equal<typeof xs, { b: number[]; a: 42; c: '!' }>>;
+          return [];
+        }
+      )
       .otherwise(() => []);
   });
 
   describe('exhaustiveness checking', () => {
-    it('catch-all wildcards', () => {
+    it('1 catch-all wildcards', () => {
       const xs: (string | number)[] = [1, 2, 3, 'a', 'b', 'c'];
 
       match(xs)
@@ -121,6 +179,41 @@ describe('variadic tuples ([a, ...b[]])', () => {
         .exhaustive();
 
       const res = match(xs)
+        .with([P.any, ...P.array()], (xs) => {
+          return 'branch 1' as const;
+        })
+        .with([], (xs) => {
+          return 'branch 2' as const;
+        })
+        .exhaustive();
+
+      type t = Expect<Equal<typeof res, 'branch 1' | 'branch 2'>>;
+    });
+
+    it('2 catch-all wildcards', () => {
+      const xs: (string | number)[] = [1, 2, 3, 'a', 'b', 'c'];
+
+      match(xs)
+        .with([P.any, P.any, ...P.array()], (xs) => {
+          return 'branch 1' as const;
+        })
+        // @ts-expect-error: empty list case missing
+        .exhaustive();
+
+      match(xs)
+        .with([P.any, P.any, ...P.array()], (xs) => {
+          return 'branch 1' as const;
+        })
+        .with([P.any, ...P.array()], (xs) => {
+          return 'branch 1' as const;
+        })
+        // @ts-expect-error: empty list case missing
+        .exhaustive();
+
+      const res = match(xs)
+        .with([P.any, P.any, ...P.array()], (xs) => {
+          return 'branch 1' as const;
+        })
         .with([P.any, ...P.array()], (xs) => {
           return 'branch 1' as const;
         })

--- a/tests/variadic-tuples.test.ts
+++ b/tests/variadic-tuples.test.ts
@@ -1,0 +1,14 @@
+import { match, P } from '../src';
+
+describe('variadic tuples ([a, ...b[]])', () => {
+  it('', () => {
+    const xs: unknown[] = [1, 2, 3, 'a', 'b', 'c'];
+
+    match(xs)
+      .with([P.any, ...P.array()], (xs) => [])
+      .with([...P.array(), 7], (xs) => [])
+      .with([42 as const, ...P.array(P.number)], (xs) => [])
+      .with([42, ...P.array(P.number), '!'] as const, (xs) => [])
+      .otherwise(() => []);
+  });
+});


### PR DESCRIPTION
Enable matching on arrays using the spread syntax:

```ts
const xs: unknown[] = [1, 2, 3, 'a', 'b', 'c'];

match(xs)
  .with([P.any, ...P.array()], (xs) => [])             // xs: [unknown, ...unknown[]]
  .with([...P.array(), 7], (xs) => [])                 // xs: [...unknown[], number]
  .with([42, ...P.array(P.number)], (xs) => [])        // xs: [42, ...number[]]
  .with([42, ...P.array(P.number), '!'], (xs) => [])   // xs: [42, ...number[], '!']
  .with([1, 2, ...P.array(P.number)], (xs) => [])      // xs: [1, 2, ...number[]]
  .with([...P.array(P.string), 'a', 'b'], (xs) => [])  // xs: [...string[], 'a', 'b']
  .otherwise(() => [])
```

Related issue: https://github.com/gvergnaud/ts-pattern/issues/105