### PR TITLE
Add lib es2015 to tsconfig

### DIFF
--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "lib": ["ES2015"]
   }
 }


### PR DESCRIPTION
Fixing an issue when running `tsc` inside the examples directory from a newly cloned repo, it errors out like below:

```
node_modules/ts-pattern/dist/types/BuildMany.d.ts:18:110 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

18 ] : never : data extends readonly (infer a)[] ? Update<a, value, Cast<tail, PropertyKey[]>>[] : data extends Set<infer a> ? Set<Update<a, value, Cast<tail, PropertyKey[]>>> : data extends Map<infer k, infer v> ? Map<k, Update<v, value, Cast<tail, PropertyKey[]>>> : Compute<Omit<data, Cast<head, PropertyKey>> & {
                                                                                                                ~~~

node_modules/ts-pattern/dist/types/BuildMany.d.ts:18:125 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

18 ] : never : data extends readonly (infer a)[] ? Update<a, value, Cast<tail, PropertyKey[]>>[] : data extends Set<infer a> ? Set<Update<a, value, Cast<tail, PropertyKey[]>>> : data extends Map<infer k, infer v> ? Map<k, Update<v, value, Cast<tail, PropertyKey[]>>> : Compute<Omit<data, Cast<head, PropertyKey>> & {
...
```

# How to reproduce

tsc Version 4.8.4
node Version v16.13.1
npm Version 8.1.2

```
cd ts-pattern/examples
npm install
tsc
```

