### PR TITLE
[narrowing] Make subsequent .with clause inherit narrowing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-pattern",
-  "version": "4.0.6",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-pattern",
-      "version": "4.0.6",
+      "version": "4.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "4.0.6",
+  "version": "4.1.0",
   "description": " The exhaustive Pattern Matching library for TypeScript.",
   "type": "module",
   "source": "src/index.ts",

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -14,8 +14,6 @@ export type MatchedValue<a, invpattern> = WithDefault<
 
 export type PickReturnValue<a, b> = a extends symbols.unset ? b : a;
 
-type ExcludeMatched<a, b> = unknown extends b ? a : Exclude<a, b>;
-
 type NonExhaustiveError<i> = { __nonExhaustive: never } & i;
 
 /**
@@ -37,7 +35,8 @@ export type Match<
   with<
     p extends Pattern<i>,
     c,
-    value extends MatchedValue<i, InvertPattern<p>>
+    value extends MatchedValue<i, InvertPattern<p>>,
+    x = InvertPatternForExclude<p, value>
   >(
     pattern: p,
     handler: (
@@ -46,7 +45,7 @@ export type Match<
     ) => PickReturnValue<o, c>
   ): [InvertPatternForExclude<p, value>] extends [infer excluded]
     ? Match<
-        ExcludeMatched<i, excluded>,
+        Exclude<i, excluded>,
         o,
         [...patternValueTuples, excluded],
         Union<inferredOutput, c>
@@ -68,7 +67,7 @@ export type Match<
     InvertPatternForExclude<p2, value>
   ] extends [infer excluded1, infer excluded2]
     ? Match<
-        ExcludeMatched<i, excluded1 | excluded2>,
+        Exclude<i, excluded1 | excluded2>,
         o,
         [...patternValueTuples, excluded1, excluded2],
         Union<inferredOutput, c>
@@ -103,10 +102,7 @@ export type Match<
     infer excludedRest extends any[]
   ]
     ? Match<
-        ExcludeMatched<
-          i,
-          excluded1 | excluded2 | excluded3 | excludedRest[number]
-        >,
+        Exclude<i, excluded1 | excluded2 | excluded3 | excludedRest[number]>,
         o,
         [
           ...patternValueTuples,
@@ -133,7 +129,7 @@ export type Match<
     ) => PickReturnValue<o, c>
   ): pred extends (value: any) => value is infer narrowed
     ? Match<
-        ExcludeMatched<i, narrowed>,
+        Exclude<i, narrowed>,
         o,
         [...patternValueTuples, narrowed],
         Union<inferredOutput, c>
@@ -151,7 +147,7 @@ export type Match<
     handler: (value: value) => PickReturnValue<o, c>
   ): pred extends (value: any) => value is infer narrowed
     ? Match<
-        ExcludeMatched<i, narrowed>,
+        Exclude<i, narrowed>,
         o,
         [...patternValueTuples, narrowed],
         Union<inferredOutput, c>

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -204,3 +204,11 @@ export type GuardValue<fn> = fn extends (value: any) => value is infer b
 export type GuardFunction<input, narrowed> =
   | ((value: input) => value is Cast<narrowed, input>)
   | ((value: input) => boolean);
+
+export type Some<bools extends boolean[]> = true extends bools[number]
+  ? true
+  : false;
+
+export type All<bools extends boolean[]> = bools[number] extends true
+  ? true
+  : false;

--- a/tests/instance-of.test.ts
+++ b/tests/instance-of.test.ts
@@ -47,13 +47,13 @@ describe('instanceOf', () => {
 
   it('issue #63: should work on union of errors', () => {
     class FooError extends Error {
-      constructor(public foo?: string) {
+      constructor(public foo: string) {
         super();
       }
     }
 
     class BazError extends Error {
-      constructor(public baz?: string) {
+      constructor(public baz: string) {
         super();
       }
     }

--- a/tests/multiple-patterns.test.ts
+++ b/tests/multiple-patterns.test.ts
@@ -88,21 +88,6 @@ describe('Multiple patterns', () => {
     match(input)
       // @ts-expect-error: Argument of type '() => false' is not assignable to parameter of type 'ExhaustivePattern<Option<number>>'
       .with(() => false);
-
-    match(input)
-      // @ts-expect-error: Argument of type '() => false' is not assignable to parameter of type 'Pattern<Option<number>>'
-      .with(() => false);
-
-    match(input)
-      // @ts-expect-error: Argument of type '() => false' is not assignable to parameter of type 'ExhaustivePattern<Option<number>>'
-      .with(() => false)
-      .with(
-        { kind: 'some', value: 2 as const },
-        { kind: 'some', value: 3 as const },
-        { kind: 'some', value: 4 as const },
-        (x) => true
-      )
-      .with({ kind: 'none' }, { kind: 'some' }, () => false);
   });
 
   it('should work with literal types', () => {

--- a/tests/not.test.ts
+++ b/tests/not.test.ts
@@ -49,7 +49,7 @@ describe('not', () => {
           type t = Expect<Equal<typeof x, 'one'>>;
           return 'not 2';
         })
-        .run();
+        .exhaustive();
 
     expect(get('two')).toEqual('not 1');
     expect(get('one')).toEqual('not 2');

--- a/tests/not.test.ts
+++ b/tests/not.test.ts
@@ -88,7 +88,7 @@ describe('not', () => {
           type t = Expect<Equal<typeof x, { type: 'error' }>>;
           return 'error';
         })
-        .with({ type: P.not('error') }, (x) => {
+        .with({ type: 'success' }, (x) => {
           type t = Expect<Equal<typeof x, { type: 'success' }>>;
           return 'success';
         })

--- a/tests/optional.test.ts
+++ b/tests/optional.test.ts
@@ -49,39 +49,56 @@ describe('optional', () => {
       | { type: 'a'; a?: { name: string; age: number } }
       | { type: 'b'; b?: 'test' };
 
+    const input = { type: 'b' } as Input;
+
+    match(input).with(
+      { type: 'a', a: P.optional({ name: P.select() }) },
+      (x) => {
+        type t = Expect<Equal<typeof x, string | undefined>>;
+        return x;
+      }
+    );
+
+    match(input).with({ type: 'a', a: P.optional(P.select()) }, (x) => {
+      type t = Expect<
+        Equal<typeof x, { name: string; age: number } | undefined>
+      >;
+      return x;
+    });
+
+    match(input).with(
+      { type: 'b', b: P.select(P.optional(P.union('test'))) },
+      (x) => {
+        type t = Expect<Equal<typeof x, 'test' | undefined>>;
+        return x;
+      }
+    );
+
+    match(input).with({ a: P.not(undefined) }, (x) => {
+      type t = Expect<
+        Equal<
+          typeof x,
+          {
+            type: 'a';
+            a: {
+              name: string;
+              age: number;
+            };
+          }
+        >
+      >;
+      return '1';
+    });
+
     const f = (input: Input) =>
       match(input)
         .with({ type: 'a', a: P.optional({ name: P.select() }) }, (x) => {
           type t = Expect<Equal<typeof x, string | undefined>>;
           return x;
         })
-        .with({ type: 'a', a: P.optional(P.select()) }, (x) => {
-          type t = Expect<
-            Equal<typeof x, { name: string; age: number } | undefined>
-          >;
-          return x;
-        })
         .with({ type: 'b', b: P.optional(P.select(P.union('test'))) }, (x) => {
           type t = Expect<Equal<typeof x, 'test' | undefined>>;
           return x;
-        })
-        .with({ a: undefined }, (x) => {
-          return '1';
-        })
-        .with({ a: P.not(undefined) }, (x) => {
-          type t = Expect<
-            Equal<
-              typeof x,
-              {
-                type: 'a';
-                a: {
-                  name: string;
-                  age: number;
-                };
-              }
-            >
-          >;
-          return '1';
         })
         .exhaustive();
 
@@ -105,12 +122,6 @@ describe('optional', () => {
           }
         )
         .with({ b: 'b' }, (x) => {
-          return '1';
-        })
-        .with({ a: undefined }, (x) => {
-          return '1';
-        })
-        .with({ a: P.not(undefined) }, (x) => {
           return '1';
         })
         .exhaustive()

--- a/tests/real-world.test.ts
+++ b/tests/real-world.test.ts
@@ -108,7 +108,7 @@ describe('real world example of a complex input type', () => {
         (queries) => queries
       )
       .with(
-        { viz: 'sunburst', requests: P.array({ response_format: P.select() }) },
+        { viz: 'geomap', requests: P.array({ response_format: P.select() }) },
         (scalars) => scalars
       )
       .with(
@@ -118,8 +118,6 @@ describe('real world example of a complex input type', () => {
             'timeseries',
             'heatmap',
             'scatterplot',
-            'sunburst',
-            'wildcard',
             'query_table'
           ),
         },

--- a/tests/tuples.test.ts
+++ b/tests/tuples.test.ts
@@ -94,15 +94,7 @@ describe('tuple ([a, b])', () => {
               type t = Expect<Equal<typeof x, [string, number]>>;
               return `not matching`;
             })
-            .with([P._, P._], (x) => {
-              type t = Expect<Equal<typeof x, [string, number]>>;
-              return `can't happen`;
-            })
-            .with(P._, (x) => {
-              type t = Expect<Equal<typeof x, [string, number]>>;
-              return `can't happen`;
-            })
-            .run()
+            .exhaustive()
         ).toEqual(expected);
       });
     });

--- a/tests/type-error.test.ts
+++ b/tests/type-error.test.ts
@@ -20,12 +20,14 @@ describe('type errors', () => {
     match<Country>('France')
       // @ts-expect-error: 'Spai' instead of 'Spain'
       .with('France', 'Germany', 'Spai', (x) => 'Europe')
+      // @ts-expect-error
       .exhaustive();
 
     match<Country>('Germany')
       .with('Germany', 'Spain', () => 'Europe')
       // @ts-expect-error: 'US' instead of 'USA'
       .with('US', (x) => 'America')
+      // @ts-expect-error
       .exhaustive();
   });
 
@@ -37,6 +39,7 @@ describe('type errors', () => {
         type t = Expect<Equal<typeof x, 'France' | 'USA'>>;
         return 'America';
       })
+      // @ts-expect-error
       .exhaustive();
   });
 
@@ -46,12 +49,16 @@ describe('type errors', () => {
         .with({ kind: 'some', value: { x: 2 } }, () => '2')
         // @ts-expect-error, value.x should be a number
         .with({ value: { x: '' } }, () => '2')
+        .with({ kind: 'none' }, () => '')
+        .with({ kind: 'some' }, () => '')
         .exhaustive();
 
     const f2 = (input: Option<number>) =>
       match(input)
         // @ts-expect-error: value is a number
         .with({ kind: 'some', value: 'string' }, () => '')
+        .with({ kind: 'none' }, () => '')
+        .with({ kind: 'some' }, () => '')
         .exhaustive();
   });
 

--- a/tests/type-error.test.ts
+++ b/tests/type-error.test.ts
@@ -20,7 +20,6 @@ describe('type errors', () => {
     match<Country>('France')
       // @ts-expect-error: 'Spai' instead of 'Spain'
       .with('France', 'Germany', 'Spai', (x) => 'Europe')
-      .with('USA', () => 'America')
       .exhaustive();
 
     match<Country>('Germany')
@@ -35,7 +34,7 @@ describe('type errors', () => {
       .with('Germany', 'Spain', () => 'Europe')
       // @ts-expect-error: 'US' instead of 'USA'
       .with('US', (x) => {
-        type t = Expect<Equal<typeof x, Country>>;
+        type t = Expect<Equal<typeof x, 'France' | 'USA'>>;
         return 'America';
       })
       .exhaustive();
@@ -47,16 +46,12 @@ describe('type errors', () => {
         .with({ kind: 'some', value: { x: 2 } }, () => '2')
         // @ts-expect-error, value.x should be a number
         .with({ value: { x: '' } }, () => '2')
-        .with({ kind: 'some' }, () => '2')
-        .with({ kind: 'none' }, () => '')
-        .with({ kind: 'some', value: P.any }, () => '')
         .exhaustive();
 
     const f2 = (input: Option<number>) =>
       match(input)
         // @ts-expect-error: value is a number
         .with({ kind: 'some', value: 'string' }, () => '')
-        .with({ kind: 'none' }, () => 0)
         .exhaustive();
   });
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -105,50 +105,53 @@ describe('types', () => {
   it('should infer values correctly in handler', () => {
     type Input = { type: string; hello?: { yo: number } } | string;
 
-    const res = match<Input>({ type: 'hello' })
-      .with(P._, (x) => {
+    match<Input>({ type: 'hello' }).with(P.string, (x) => {
+      type t = Expect<Equal<typeof x, string>>;
+      return 'ok';
+    });
+
+    const res = match<Input>({ type: 'hello' }).with(P.string, (x) => {
+      type t = Expect<Equal<typeof x, string>>;
+      return 'ok';
+    });
+
+    match<Input>({ type: 'hello' }).with(
+      P.when((x) => true),
+      (x) => {
         type t = Expect<Equal<typeof x, Input>>;
         return 'ok';
-      })
-      .with(P.string, (x) => {
-        type t = Expect<Equal<typeof x, string>>;
-        return 'ok';
-      })
-      .with(
-        P.when((x) => true),
-        (x) => {
-          type t = Expect<Equal<typeof x, Input>>;
-          return 'ok';
-        }
-      )
-      .with(
-        P.typed<Input>().when((x) => {
-          type t = Expect<Equal<typeof x, Input>>;
-          return true;
-        }),
-        (x) => {
-          type t = Expect<Equal<typeof x, Input>>;
-          return 'ok';
-        }
-      )
-      .with(P.not('hello' as const), (x) => {
+      }
+    );
+
+    match<Input>({ type: 'hello' }).with(
+      P.typed<Input>().when((x) => {
+        type t = Expect<Equal<typeof x, Input>>;
+        return true;
+      }),
+      (x) => {
         type t = Expect<Equal<typeof x, Input>>;
         return 'ok';
-      })
-      .with(P.not(P.string), (x) => {
-        type t = Expect<
-          Equal<
-            typeof x,
-            {
-              type: string;
-              hello?: {
-                yo: number;
-              };
-            }
-          >
-        >;
-        return 'ok';
-      })
+      }
+    );
+    match<Input>({ type: 'hello' }).with(P.not('hello' as const), (x) => {
+      type t = Expect<Equal<typeof x, Input>>;
+      return 'ok';
+    });
+    match<Input>({ type: 'hello' }).with(P.not(P.string), (x) => {
+      type t = Expect<
+        Equal<
+          typeof x,
+          {
+            type: string;
+            hello?: {
+              yo: number;
+            };
+          }
+        >
+      >;
+      return 'ok';
+    });
+    match<Input>({ type: 'hello' })
       .with(P.not(P.when((x) => true)), (x) => {
         type t = Expect<Equal<typeof x, Input>>;
         return 'ok';
@@ -166,20 +169,22 @@ describe('types', () => {
           >
         >;
         return 'ok';
-      })
-      .with({ type: P.string }, (x) => {
-        type t = Expect<
-          Equal<typeof x, { type: string; hello?: { yo: number } | undefined }>
-        >;
-        return 'ok';
-      })
-      .with({ type: P.when((x) => true) }, (x) => {
-        type t = Expect<
-          Equal<typeof x, { type: string; hello?: { yo: number } | undefined }>
-        >;
-        return 'ok';
-      })
-      .with({ type: P.not('hello' as 'hello') }, (x) => {
+      });
+    match<Input>({ type: 'hello' }).with({ type: P.string }, (x) => {
+      type t = Expect<
+        Equal<typeof x, { type: string; hello?: { yo: number } | undefined }>
+      >;
+      return 'ok';
+    });
+    match<Input>({ type: 'hello' }).with({ type: P.when((x) => true) }, (x) => {
+      type t = Expect<
+        Equal<typeof x, { type: string; hello?: { yo: number } | undefined }>
+      >;
+      return 'ok';
+    });
+    match<Input>({ type: 'hello' }).with(
+      { type: P.not('hello' as 'hello') },
+      (x) => {
         type t = Expect<
           Equal<
             typeof x,
@@ -194,26 +199,34 @@ describe('types', () => {
           >
         >;
         return 'ok';
-      })
-      .with({ type: P.not(P.string) }, (x) => {
+      }
+    );
+    match<Input>({ type: 'hello' }).with({ type: P.not(P.string) }, (x) => {
+      type t = Expect<Equal<typeof x, Input>>;
+      return 'ok';
+    });
+    match<Input>({ type: 'hello' }).with(
+      { type: P.not(P.when((x) => true)) },
+      (x) => {
         type t = Expect<Equal<typeof x, Input>>;
         return 'ok';
-      })
-      .with({ type: P.not(P.when((x) => true)) }, (x) => {
-        type t = Expect<Equal<typeof x, Input>>;
-        return 'ok';
-      })
-      .with(P.not({ type: P.when((x) => true) }), (x) => {
+      }
+    );
+    match<Input>({ type: 'hello' }).with(
+      P.not({ type: P.when((x) => true) }),
+      (x) => {
         type t = Expect<Equal<typeof x, string>>;
         return 'ok';
-      })
-      .with(P.not({ type: P.string }), (x) => {
-        type t = Expect<Equal<typeof x, string>>;
-        return 'ok';
-      })
-      .run();
-
-    const inferenceCheck: string = res;
+      }
+    );
+    match<Input>({ type: 'hello' }).with(P.not({ type: P.string }), (x) => {
+      type t = Expect<Equal<typeof x, string>>;
+      return 'ok';
+    });
+    match<Input>({ type: 'hello' }).with(P._, (x) => {
+      type t = Expect<Equal<typeof x, Input>>;
+      return 'ok';
+    });
   });
 
   it('a union of object or primitive should be matched with a correct type inference', () => {
@@ -221,15 +234,11 @@ describe('types', () => {
       | string
       | number
       | boolean
-      | { type: string }
+      | { type: string | number }
       | string[]
       | [number, number];
 
     match<Input>({ type: 'hello' })
-      .with({ type: P._ }, (x) => {
-        type t = Expect<Equal<typeof x, { type: string }>>;
-        return 'ok';
-      })
       .with(P.string, (x) => {
         type t = Expect<Equal<typeof x, string>>;
         return 'ok';
@@ -244,6 +253,10 @@ describe('types', () => {
       })
       .with({ type: P.string }, (x) => {
         type t = Expect<Equal<typeof x, { type: string }>>;
+        return 'ok';
+      })
+      .with({ type: P._ }, (x) => {
+        type t = Expect<Equal<typeof x, { type: string | number }>>;
         return 'ok';
       })
       .with([P.string], (x) => {

--- a/tests/unions.test.ts
+++ b/tests/unions.test.ts
@@ -38,11 +38,11 @@ describe('Unions (a | b)', () => {
       id: 2,
       content: { body: 'yo' },
     })
-      .with({ type: 'post', content: P._ }, (x) => {
+      .with({ type: 'post', id: 7 }, (x) => {
         type t = Expect<Equal<typeof x, Post>>;
         return 1;
       })
-      .with({ type: 'post', id: 7 }, (x) => {
+      .with({ type: 'post', content: P._ }, (x) => {
         type t = Expect<Equal<typeof x, Post>>;
         return 1;
       })


### PR DESCRIPTION
# Make subsequent `.with` clause inherit narrowing from previous clauses

## Problem

With the current version of ts-pattern, nothing prevents you from writing `.with` clauses that will never match any input because the case has already been handled in a previous close:

```ts
type Plan = 'free' | 'pro' | 'premium';

const welcome = (plan: Plan) => 
  match(plan)
    .with('free', () => 'Hello free user!')
    .with('pro', () => 'Hello pro user!')
    .with('pro', () => 'Hello awesome user!')
    //      👆 This will never match!
    //         We should exclude "pro"
    //         from the input type to 
    //         reject duplicated with clauses. 
    .with('premium', () => 'Hello premium user!')
    .exhaustive()
```

## Approach

Initially, I was reluctant to narrow the input type on every call of `.with` because of type checking performance. TS-Pattern's exhaustive checking is pretty expensive because it not only narrows top-level union types, but also nested ones. In order to make that work, TS-Pattern needs to **distribute** nested union types when they are matched by a pattern, which can sometimes generate large unions which are more expensive to match.

I ended up settling on a more modest approach, which turns out to have great performance: Only narrowing top level union types. This should cover 80% of cases, including the aforementioned one:

```ts
type Plan = 'free' | 'pro' | 'premium';

const welcome = (plan: Plan) => 
  match(plan)
    .with('free', () => 'Hello free user!')
    .with('pro', () => 'Hello pro user!')
    .with('pro', () => 'Hello awesome user!')
    //       ^ ❌ Does not type-check in TS-Pattern v4.1!
    .with('premium', () => 'Hello premium user!')
    .exhaustive()
```

### Examples of invalid cases that no longer type check:

Narrowing will work on unions of literals, but also discriminated unions of objects:


```ts
type Entity =
  | { type: 'user', name: string }
  | { type: 'org', id: string };

const f = (entity: Entity) => 
  match(entity)
    .with({ type: 'user' }, () => 'user!')
    .with({ type: 'user' }, () => 'user!')
    //                   ^ ❌ Does not type-check in TS-Pattern v4.1!
    .with({ type: 'org' }, () => 'org!')
    .exhaustive()
```

It also works with tuples, and any other union of data structures:

```ts
type Entity =
  | [type: 'user', name: string]
  | [type: 'org', id: string]

const f = (entity: Entity) => 
  match(entity)
    .with(['user', P.any], () => 'user!')
    .with(['user', P.any], () => 'user!')
    //      ^ ❌ Does not type-check in TS-Pattern v4.1!
    .with(['org', P.any], () => 'org!')
    .exhaustive()
```

It works with any patterns, including wildcards:

```ts
type Entity =
  | [type: 'user', name: string]
  | [type: 'org', id: string]

const f = (entity: Entity) => 
  match(entity)
    .with(P.any, () => 'user!') // catch all
    .with(['user', P.any], () => 'user!')
    //      ^ ❌ Does not type-check in TS-Pattern v4.1!
    .with(['org', P.any], () => 'org!')
    //      ^ ❌ Does not type-check in TS-Pattern v4.1!
    .exhaustive()
```

### Examples of invalid cases that _still_ type check:

This won't prevent you from writing duplicated clauses in case the union you're matching is nested:

```ts
type Plan = 'free' | 'pro' | 'premium';
type Role = 'viewer' | 'contributor' | 'admin';

const f = (plan: Plan, role: Role) => 
  match([plan, role] as const)
    .with(['free', 'admin'], () => 'free admin')
    .with(['pro', P.any], () => 'all pros')
    .with(['pro', 'admin'], () => 'admin pro')
    //            ^ this unfortunately still type-check
    .otherwise(() => 'other users!')
```




## Perf

Type-checking performance is generally better, with a 29% reduction of type instantiation and a 17% check time  improvement on my benchmark:

| description               | before  | after   | delta   |
| ------------------------- | ------- | ------- | ------- |
| Files                     | 181     | 181     | 0%      |
| Lines of Library          | 28073   | 28073   | 0%      |
| Lines of Definitions      | 49440   | 49440   | 0%      |
| Lines of TypeScript       | 11448   | 11516   | 0.59%   |
| Nodes of Library          | 119644  | 119644  | 0%      |
| Nodes of Definitions      | 192409  | 192409  | 0%      |
| Nodes of TypeScript       | 57791   | 58151   | 0.62%   |
| Identifiers               | 120063  | 120163  | 0.08%   |
| Symbols                   | 746269  | 571935  | -23.36% |
| Types                     | 395519  | 333052  | -15.79% |
| Instantiations            | 3810512 | 2670937 | -29.90% |
| Memory used               | 718758K | 600076K | -16.51% |
| Assignability cache size  | 339114  | 311641  | -8.10%  |
| Identity cache size       | 17071   | 17036   | -0.20%  |
| Subtype cache size        | 2759    | 2739    | -0.72%  |
| Strict subtype cache size | 2544    | 1981    | -22.13% |
| I/O Read time             | 0.01s   | 0.01s   | 0%      |
| Parse time                | 0.28s   | 0.28s   | 0%      |
| ResolveModule time        | 0.01s   | 0.02s   | 100%    |
| ResolveTypeReference time | 0.01s   | 0.01s   | 0%      |
| Program time              | 0.34s   | 0.34s   | 0%      |
| Bind time                 | 0.13s   | 0.14s   | 7.69%   |
| Check time                | 5.28s   | 4.37s   | -17.23% |
| Total time                | 5.75s   | 4.85s   | -15.65% |

