### PR TITLE
Add `nodeNext` and `node16` support

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,4 +1,11 @@
+
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  transform: {'\\.[jt]sx?$': ['ts-jest', { useESM: true }] },
+  moduleNameMapper: {
+    '(.+)\\.js': '$1',
+  },
+  extensionsToTreatAsEsm: ['.ts', '.mts']
 };

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.modern.js"
     },
+    "./types/*": "./dist/types/*",
+    "./internals/*": "./dist/internals/*",
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
@@ -18,14 +20,14 @@
   "module": "./dist/index.module.js",
   "unpkg": "./dist/index.umd.js",
   "scripts": {
-    "build": "microbundle",
-    "dev": "microbundle watch",
+    "build": "microbundle --tsconfig ./tsconfig.prod.json",
+    "dev": "microbundle watch --tsconfig ./tsconfig.prod.json",
     "prepublishOnly": "npm run test && npm run build",
     "test": "jest",
     "clear-test": "jest --clearCache",
-    "perf": "tsc --project tests/tsconfig.json --noEmit --extendedDiagnostics",
+    "perf": "./node_modules/.bin/tsc --project tests/tsconfig.json --noEmit --extendedDiagnostics",
     "fmt": "prettier ./src/** ./tests/** -w",
-    "check": "tsc --strict --noEmit --extendedDiagnostics"
+    "check": "./node_modules/.bin/tsc --project tsconfig.prod.json --strict --noEmit --extendedDiagnostics"
   },
   "files": [
     "dist/**/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "4.1.4",
+  "version": "4.1.4-nodenext.0",
   "description": " The exhaustive Pattern Matching library for TypeScript.",
   "type": "module",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "4.1.4-nodenext.0",
+  "version": "4.1.4-nodenext.1",
   "description": " The exhaustive Pattern Matching library for TypeScript.",
   "type": "module",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
-  "types": "dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "module": "./dist/index.module.js",
   "unpkg": "./dist/index.umd.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import * as Pattern from './patterns';
+import * as Pattern from './patterns.js';
 
-export { match } from './match';
-export { isMatching } from './is-matching';
+export { match } from './match.js';
+export { isMatching } from './is-matching.js';
 export { Pattern, Pattern as P };

--- a/src/internals/helpers.ts
+++ b/src/internals/helpers.ts
@@ -4,9 +4,9 @@
  * @internal
  */
 
-import * as symbols from './symbols';
-import { SelectionType } from '../types/FindSelected';
-import { Pattern, Matcher, MatcherType } from '../types/Pattern';
+import * as symbols from './symbols.js';
+import { SelectionType } from '../types/FindSelected.js';
+import { Pattern, Matcher, MatcherType } from '../types/Pattern.js';
 
 // @internal
 export const isObject = (value: unknown): value is Object =>

--- a/src/is-matching.ts
+++ b/src/is-matching.ts
@@ -1,7 +1,7 @@
-import { Pattern } from './types/Pattern';
-import { MatchedValue } from './types/Match';
-import * as P from './patterns';
-import { matchPattern } from './internals/helpers';
+import { Pattern } from './types/Pattern.js';
+import { MatchedValue } from './types/Match.js';
+import * as P from './patterns.js';
+import { matchPattern } from './internals/helpers.js';
 
 /**
  * `isMatching` takes pattern and returns a **type guard** function, cheching if a value matches this pattern.

--- a/src/match.ts
+++ b/src/match.ts
@@ -1,8 +1,8 @@
-import { Pattern } from './types/Pattern';
-import { GuardValue } from './types/helpers';
-import { Match, PickReturnValue } from './types/Match';
-import * as symbols from './internals/symbols';
-import { matchPattern } from './internals/helpers';
+import { Pattern } from './types/Pattern.js';
+import { GuardValue } from './types/helpers.js';
+import { Match, PickReturnValue } from './types/Match.js';
+import * as symbols from './internals/symbols.js';
+import { matchPattern } from './internals/helpers.js';
 
 /**
  * `match` creates a **pattern matching expression**.

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -1,7 +1,7 @@
-import { matchPattern, getSelectionKeys, flatMap } from './internals/helpers';
-import * as symbols from './internals/symbols';
-import { GuardFunction } from './types/helpers';
-import { InvertPattern } from './types/InvertPattern';
+import { matchPattern, getSelectionKeys, flatMap } from './internals/helpers.js';
+import * as symbols from './internals/symbols.js';
+import { GuardFunction } from './types/helpers.js';
+import { InvertPattern } from './types/InvertPattern.js';
 import {
   Pattern,
   UnknownPattern,
@@ -14,7 +14,7 @@ import {
   SelectP,
   AnonymousSelectP,
   GuardExcludeP,
-} from './types/Pattern';
+} from './types/Pattern.js';
 
 export { Pattern };
 

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -1,4 +1,8 @@
-import { matchPattern, getSelectionKeys, flatMap } from './internals/helpers.js';
+import {
+  matchPattern,
+  getSelectionKeys,
+  flatMap,
+} from './internals/helpers.js';
 import * as symbols from './internals/symbols.js';
 import { GuardFunction } from './types/helpers.js';
 import { InvertPattern } from './types/InvertPattern.js';

--- a/src/types/BuildMany.ts
+++ b/src/types/BuildMany.ts
@@ -1,4 +1,4 @@
-import { Cast, Compute, Iterator, UpdateAt } from './helpers';
+import { Cast, Compute, Iterator, UpdateAt } from './helpers.js';
 
 // BuildMany :: DataStructure -> Union<[value, path][]> -> Union<DataStructure>
 export type BuildMany<data, xs extends any[]> = xs extends any

--- a/src/types/DeepExclude.ts
+++ b/src/types/DeepExclude.ts
@@ -1,3 +1,3 @@
-import { DistributeMatchingUnions } from './DistributeUnions';
+import { DistributeMatchingUnions } from './DistributeUnions.js';
 
 export type DeepExclude<a, b> = Exclude<DistributeMatchingUnions<a, b>, b>;

--- a/src/types/DistributeUnions.ts
+++ b/src/types/DistributeUnions.ts
@@ -1,4 +1,4 @@
-import { BuildMany } from './BuildMany';
+import { BuildMany } from './BuildMany.js';
 import type {
   IsAny,
   Cast,
@@ -8,8 +8,8 @@ import type {
   IsPlainObject,
   Length,
   UnionToTuple,
-} from './helpers';
-import { IsMatching } from './IsMatching';
+} from './helpers.js';
+import { IsMatching } from './IsMatching.js';
 
 /**
  * DistributeMatchingUnions takes two arguments:

--- a/src/types/ExtractPreciseValue.ts
+++ b/src/types/ExtractPreciseValue.ts
@@ -1,4 +1,4 @@
-import type { ToExclude } from './Pattern';
+import type { ToExclude } from './Pattern.js';
 import type {
   BuiltInObjects,
   Compute,
@@ -6,8 +6,8 @@ import type {
   IsAny,
   IsPlainObject,
   LeastUpperBound,
-} from './helpers';
-import { DeepExclude } from './DeepExclude';
+} from './helpers.js';
+import { DeepExclude } from './DeepExclude.js';
 
 export type ExtractPreciseValue<a, b> = unknown extends b
   ? a

--- a/src/types/FindSelected.ts
+++ b/src/types/FindSelected.ts
@@ -1,6 +1,6 @@
-import type * as symbols from '../internals/symbols';
-import type { Cast, Equal, IsAny, TupleKeys, UnionToTuple } from './helpers';
-import type { Matcher, Pattern } from './Pattern';
+import type * as symbols from '../internals/symbols.js';
+import type { Cast, Equal, IsAny, TupleKeys, UnionToTuple } from './helpers.js';
+import type { Matcher, Pattern } from './Pattern.js';
 
 type SelectionsRecord = Record<string, [unknown, unknown[]]>;
 

--- a/src/types/InvertPattern.ts
+++ b/src/types/InvertPattern.ts
@@ -1,4 +1,4 @@
-import { DeepExclude } from './DeepExclude';
+import { DeepExclude } from './DeepExclude.js';
 import {
   IsPlainObject,
   Primitives,
@@ -11,8 +11,8 @@ import {
   Not,
   All,
   NonLiteralPrimitive,
-} from './helpers';
-import type { Matcher, Pattern, ToExclude } from './Pattern';
+} from './helpers.js';
+import type { Matcher, Pattern, ToExclude } from './Pattern.js';
 
 type OptionalKeys<p> = ValueOf<{
   [k in keyof p]: p[k] extends Matcher<any, any, infer matcherType>

--- a/src/types/IsMatching.ts
+++ b/src/types/IsMatching.ts
@@ -1,4 +1,4 @@
-import { Primitives, IsPlainObject, IsUnion } from './helpers';
+import { Primitives, IsPlainObject, IsUnion } from './helpers.js';
 
 export type IsMatching<a, p> = true extends IsUnion<a> | IsUnion<p>
   ? true extends (

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -1,7 +1,10 @@
 import type * as symbols from '../internals/symbols.js';
 import type { Pattern, Matcher } from './Pattern.js';
 import type { ExtractPreciseValue } from './ExtractPreciseValue.js';
-import type { InvertPatternForExclude, InvertPattern } from './InvertPattern.js';
+import type {
+  InvertPatternForExclude,
+  InvertPattern,
+} from './InvertPattern.js';
 import type { DeepExclude } from './DeepExclude.js';
 import type { WithDefault, Union, GuardValue } from './helpers.js';
 import type { FindSelected } from './FindSelected.js';

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -1,10 +1,10 @@
-import type * as symbols from '../internals/symbols';
-import type { Pattern, Matcher } from './Pattern';
-import type { ExtractPreciseValue } from './ExtractPreciseValue';
-import type { InvertPatternForExclude, InvertPattern } from './InvertPattern';
-import type { DeepExclude } from './DeepExclude';
-import type { WithDefault, Union, GuardValue } from './helpers';
-import type { FindSelected } from './FindSelected';
+import type * as symbols from '../internals/symbols.js';
+import type { Pattern, Matcher } from './Pattern.js';
+import type { ExtractPreciseValue } from './ExtractPreciseValue.js';
+import type { InvertPatternForExclude, InvertPattern } from './InvertPattern.js';
+import type { DeepExclude } from './DeepExclude.js';
+import type { WithDefault, Union, GuardValue } from './helpers.js';
+import type { FindSelected } from './FindSelected.js';
 
 // We fall back to `a` if we weren't able to extract anything more precise
 export type MatchedValue<a, invpattern> = WithDefault<

--- a/src/types/Pattern.ts
+++ b/src/types/Pattern.ts
@@ -1,6 +1,6 @@
-import type * as symbols from '../internals/symbols';
-import { Primitives } from './helpers';
-import { None, Some, SelectionType } from './FindSelected';
+import type * as symbols from '../internals/symbols.js';
+import { Primitives } from './helpers.js';
+import { None, Some, SelectionType } from './FindSelected.js';
 
 export type MatcherType =
   | 'not'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,14 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "composite": true,
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "target": "es6",
     "strict": true,
     "outDir": "dist/"
   },
-  "include": ["src/"],
-  "exclude": ["tests/", "dist/", "examples/"]
+  "include": [
+    "src"
+  ],
 }

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "dist/",
+    "tests/",
+    "examples/"
+  ]
+}

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -4,12 +4,4 @@
     "composite": true,
     "rootDir": "src",
   },
-  "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "dist/",
-    "tests/",
-    "examples/"
-  ]
 }

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -3,5 +3,8 @@
   "compilerOptions": {
     "composite": true,
     "rootDir": "src",
+    /* 🌐 https://github.com/developit/microbundle#using-with-typescript */
+    "target": "ESNext",
+    "module": "ESNext",
   },
 }


### PR DESCRIPTION
This [branch](https://github.com/Cuppachino/ts-pattern-nodenext/tree/node-next) potentially fixes #110. I used [tsup](https://github.com/egoist/tsup) to quickly try out a few common configs, but this change needs more testing.

### changes
| |  |
| - | :- |
| `jest.config.cjs` | Transform hard-coded `.js` to `.ts` during testing. |
| `package.json`| Expose `.d.ts` exports & use `tsconfig.prod.json` in scripts |
| `src/**/*.(ts\|mts\|cts)` | [regexp](https://stackoverflow.com/a/73075563/17867284) workaround. append `.js` to imports |
| `tsconfig.json` | enforce import paths end with `.js` during development |
| `tsconfig.prod.json` | extends dev config with microbundles' [recommended settings](https://github.com/developit/microbundle#using-with-typescript) |