### PR TITLE
fix: add types condition to the front of the exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.cjs",
       "import": "./dist/index.module.js",
-      "types": "./dist/index.d.ts",
       "default": "./dist/index.modern.js"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
I coincidentally saw that there is [an issue](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260) with TypeScript which could cause some potential bugs in libraries. I also saw that @Andarist was opening some pr-s ([example](https://github.com/mysticatea/regexpp/pull/30))  in popular libraries to fix the bug. So I just moved types to the top in exports.

So I think this pr should fix `🐛 Used fallback condition` [issues here](https://arethetypeswrong.github.io/?p=ts-pattern%404.2.2). 