### PR TITLE
New patterns: P.startsWith and P.endsWith

### DIFF
--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -360,6 +360,16 @@ function isInstanceOf<T extends AnyConstructor>(classConstructor: T) {
     val instanceof classConstructor;
 }
 
+function doesStartWith<T extends string>(suffix: T) {
+  return (val: unknown): val is `${T}${string}` =>
+    typeof val === 'string' && val.startsWith(suffix);
+}
+
+function doesEndWith<T extends string>(suffix: T) {
+  return (val: unknown): val is `${string}${T}` =>
+    typeof val === 'string' && val.endsWith(suffix);
+}
+
 /**
  * `P.any` is a wildcard pattern, matching **any value**.
  *
@@ -458,6 +468,34 @@ export function instanceOf<T extends AnyConstructor>(
   classConstructor: T
 ): GuardP<unknown, InstanceType<T>> {
   return when(isInstanceOf(classConstructor));
+}
+
+/**
+ * `P.startsWith(SomeString)` is a pattern matching strings that start with the given prefix.
+ *
+ * [Read documentation for `P.startsWith` on GitHub](https://github.com/gvergnaud/ts-pattern#PstartsWith-patterns)
+ *
+ *  @example
+ *   .with(P.startsWith('2023-'), () => 'will match on strings starting with 2023-')
+ */
+export function startsWith<T extends string>(
+  prefix: T
+): GuardP<unknown, `${T}${string}`> {
+  return when(doesStartWith(prefix));
+}
+
+/**
+ * `P.endsWith(SomeString)` is a pattern matching strings that end with the given suffix.
+ *
+ * [Read documentation for `P.endsWith` on GitHub](https://github.com/gvergnaud/ts-pattern#PendsWith-patterns)
+ *
+ *  @example
+ *   .with(P.endsWith('.jpg'), () => 'will match on strings ending with .jpg')
+ */
+export function endsWith<T extends string>(
+  suffix: T
+): GuardP<unknown, `${string}${T}`> {
+  return when(doesEndWith(suffix));
 }
 
 /**

--- a/tests/ends-with.test.ts
+++ b/tests/ends-with.test.ts
@@ -1,0 +1,43 @@
+import { Expect, Equal } from '../src/types/helpers';
+import { match, P } from '../src';
+
+type PngFileName = `${string}.png`;
+type JpgFileName = `${string}.jpg`;
+
+describe('endsWith', () => {
+  it('should work at the top level', () => {
+    const get = (x: PngFileName | JpgFileName): string =>
+      match(x)
+        .with(P.endsWith('.png'), (x) => {
+          type t = Expect<Equal<typeof x, PngFileName>>;
+          return 'png file name';
+        })
+        .with(P.endsWith('.jpg'), (x) => {
+          type t = Expect<Equal<typeof x, JpgFileName>>;
+          return 'jpg file name';
+        })
+        .exhaustive();
+
+    expect(get('foo.png')).toEqual('png file name');
+    expect(get('foo.jpg')).toEqual('jpg file name');
+  });
+
+  it('should work as a nested pattern', () => {
+    type Input = { value: PngFileName | JpgFileName };
+
+    const input: Input = { value: 'foo.png' };
+
+    const output = match<Input>(input)
+      .with({ value: P.endsWith('.png') }, (a) => {
+        type t = Expect<Equal<typeof a, { value: PngFileName }>>;
+        return 'nested png file name';
+      })
+      .with({ value: P.endsWith('.jpg') }, (b) => {
+        type t = Expect<Equal<typeof b, { value: JpgFileName }>>;
+        return 'nested jpg file name';
+      })
+      .exhaustive();
+
+    expect(output).toEqual('nested png file name');
+  });
+});

--- a/tests/starts-with.test.ts
+++ b/tests/starts-with.test.ts
@@ -1,0 +1,43 @@
+import { Expect, Equal } from '../src/types/helpers';
+import { match, P } from '../src';
+
+type FileFrom2022 = `2022-${number}-${number}`;
+type FileFrom2023 = `2023-${number}-${number}`;
+
+describe('endsWith', () => {
+  it('should work at the top level', () => {
+    const get = (x: FileFrom2022 | FileFrom2023): string =>
+      match(x)
+        .with(P.startsWith('2022-'), (x) => {
+          type t = Expect<Equal<typeof x, FileFrom2022>>;
+          return 'file from 2022';
+        })
+        .with(P.startsWith('2023-'), (x) => {
+          type t = Expect<Equal<typeof x, FileFrom2023>>;
+          return 'file from 2023';
+        })
+        .exhaustive();
+
+    expect(get('2022-04-01')).toEqual('file from 2022');
+    expect(get('2023-04-01')).toEqual('file from 2023');
+  });
+
+  it('should work as a nested pattern', () => {
+    type Input = { value: FileFrom2022 | FileFrom2023 };
+
+    const input: Input = { value: '2023-04-01' };
+
+    const output = match<Input>(input)
+      .with({ value: P.startsWith('2022-') }, (a) => {
+        type t = Expect<Equal<typeof a, { value: FileFrom2022 }>>;
+        return 'nested file from 2022';
+      })
+      .with({ value: P.startsWith('2023-') }, (b) => {
+        type t = Expect<Equal<typeof b, { value: FileFrom2023 }>>;
+        return 'nested file from 2023';
+      })
+      .exhaustive();
+
+    expect(output).toEqual('nested file from 2023');
+  });
+});


### PR DESCRIPTION
This PR starts two new patterns, `P.startsWith` and `P.endsWith` (I say starts because I haven't written documentation yet). For some reason, `.exhaustive()` causes a type error in `starts-with.test.ts`, but not `ends-with.test.ts`. I'm not sure what's going on yet (hence no documentation) but I'm definitely open to feedback.