### PR TITLE
Gvergnaud/fix build for nodenext and commonjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-pattern",
-  "version": "4.2.3",
+  "version": "4.2.4-test.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-pattern",
-      "version": "4.2.3",
+      "version": "4.2.4-test.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-pattern",
-  "version": "4.2.4",
+  "version": "4.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-pattern",
-      "version": "4.2.4",
+      "version": "4.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-pattern",
-  "version": "4.2.4-test.1",
+  "version": "4.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-pattern",
-      "version": "4.2.4-test.1",
+      "version": "4.2.4",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-pattern",
-  "version": "4.2.4-test.0",
+  "version": "4.2.4-test.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-pattern",
-      "version": "4.2.4-test.0",
+      "version": "4.2.4-test.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "4.2.4",
+  "version": "4.3.0",
   "description": " The exhaustive Pattern Matching library for TypeScript.",
   "type": "module",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,15 @@
   "source": "src/index.ts",
   "exports": {
     ".": {
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs",
       "default": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
@@ -18,7 +24,7 @@
   "module": "dist/index.mjs",
   "unpkg": "dist/index.umd.cjs",
   "scripts": {
-    "build": "rimraf dist && microbundle",
+    "build": "rimraf dist && microbundle && sh ./scripts/generate-cts.sh",
     "dev": "microbundle watch",
     "prepublishOnly": "npm run test && npm run build",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "4.2.4-test.0",
+  "version": "4.2.4-test.1",
   "description": " The exhaustive Pattern Matching library for TypeScript.",
   "type": "module",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -12,17 +12,17 @@
       },
       "import": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.mjs"
+        "default": "./dist/index.js"
       },
       "types": "./dist/index.d.ts",
-      "default": "./dist/index.mjs"
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
   "types": "dist/index.d.ts",
   "main": "dist/index.cjs",
-  "module": "dist/index.mjs",
-  "unpkg": "dist/index.umd.cjs",
+  "module": "dist/index.js",
+  "unpkg": "dist/index.umd.js",
   "scripts": {
     "build": "rimraf dist && microbundle && sh ./scripts/generate-cts.sh",
     "dev": "microbundle watch",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "4.2.3",
+  "version": "4.2.4-test.0",
   "description": " The exhaustive Pattern Matching library for TypeScript.",
   "type": "module",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "4.2.4-test.1",
+  "version": "4.2.4",
   "description": " The exhaustive Pattern Matching library for TypeScript.",
   "type": "module",
   "source": "src/index.ts",

--- a/scripts/generate-cts.sh
+++ b/scripts/generate-cts.sh
@@ -6,4 +6,6 @@ files=$(find dist -type f -name "*.d.ts");
 for file in $files; do
     # Update imports to include the '.cjs' extension
     sed -E "s/(.*)from '([^']*)'/\1from '\2.cjs'/g" "$file" > "${file%.d.ts}.d.cts"
+    # add `.js` extensions to .d.ts files
+    sed -i '' -e "s/\(.*\)from '\([^']*\)'/\1from '\2.js'/g" "$file"
 done

--- a/scripts/generate-cts.sh
+++ b/scripts/generate-cts.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+files=$(find dist -type f -name "*.d.ts");
+
+# Loop through the files
+for file in $files; do
+    # Update lines matching the regular expression
+    sed -E "s/(.*)from '([^']*)'/\1from '\2.cjs'/g" "$file" > "${file%.d.ts}.d.cts"
+done

--- a/scripts/generate-cts.sh
+++ b/scripts/generate-cts.sh
@@ -2,8 +2,8 @@
 
 files=$(find dist -type f -name "*.d.ts");
 
-# Loop through the files
+# Loop through the declaration files
 for file in $files; do
-    # Update lines matching the regular expression
+    # Update imports to include the '.cjs' extension
     sed -E "s/(.*)from '([^']*)'/\1from '\2.cjs'/g" "$file" > "${file%.d.ts}.d.cts"
 done

--- a/scripts/generate-cts.sh
+++ b/scripts/generate-cts.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# TypeScript projects using `moduleResolution: nodenext` expect
+# explicit extensions to be included in declaration files,
+# and to have a different set of declarations for commonjs
+# modules (.d.cts) and ES modules (.d.ts). `tsc` unfortunately
+# doesn't provide a way to generate these declarations files,
+# so I'm manually creating them in this script.
+
 files=$(find dist -type f -name "*.d.ts");
 
 # Loop through the declaration files


### PR DESCRIPTION
Update ts-pattern's exports map and build to fully support commonjs and esmodules in `nodenext` projects.

https://arethetypeswrong.github.io/?p=ts-pattern%404.2.4-test.1

<img width="478" alt="image" src="https://user-images.githubusercontent.com/9265418/236694463-af8e8938-e825-471c-bc84-504b823591ae.png">


This PR should fix: https://github.com/gvergnaud/ts-pattern/issues/110