### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,12 +510,12 @@ function with(
   - Additional condition the input must satisfy for the handler to be called.
   - The input will match if your guard function returns a truthy value.
   - `TInput` might be narrowed to a more precise type using the `pattern`.
-- `handler: (value: TInput, selections: Selections<TInput>) => TOutput`
+- `handler: (selections: Selections<TInput>, value: TInput) => TOutput`
   - **Required**
   - Function called when the match conditions are satisfied.
   - All handlers on a single `match` case must return values of the same type, `TOutput`.
-  - `TInput` might be narrowed to a more precise type using the `pattern`.
   - `selections` is an object of properties selected from the input with the [`select` function](#select-patterns).
+  - `TInput` might be narrowed to a more precise type using the `pattern`.
 
 ### `.when`
 


### PR DESCRIPTION
Update the docs for `.with` `handler` arguments.  I believe `selections` are supposed to come before `value`.

If `selections` are only injected as the first argument if/when a selection(s) is made, should we also maybe make note of that again here in the docs?