### PR TITLE
🐛 fix: Allow re-exporting patterns from ES Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1531,6 +1531,20 @@ const posts = await fetch(someUrl)
 
 Although not strictly necessary, using `as const` after the pattern definition ensures that TS-Pattern infers the most precise types possible.
 
+### `P.narrow`
+
+`P.narrow<Input, typeof Pattern>` will narrow the input type to only keep the set of values that are compatible with the provided pattern type.
+
+```ts
+type Input = ['a' | 'b' | 'c', 'a' | 'b' | 'c'];
+const Pattern = ['a', P.union('a', 'b')] as const;
+
+type Narrowed = P.narrow<Input, typeof Pattern>;
+//     ^? ['a', 'a' | 'b']
+```
+
+Note that most of the time, the `match` and `isMatching` functions perform narrowing for you, and you do not need to narrow types yourself.
+
 ### `P.Pattern`
 
 `P.Pattern<T>` is the type of all possible pattern for a generic type `T`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-pattern",
-  "version": "5.0.2",
+  "version": "5.0.3-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-pattern",
-      "version": "5.0.2",
+      "version": "5.0.3-rc.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-pattern",
-  "version": "5.0.3-rc.1",
+  "version": "5.0.3-rc.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-pattern",
-      "version": "5.0.3-rc.1",
+      "version": "5.0.3-rc.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-pattern",
-  "version": "5.0.3-rc.2",
+  "version": "5.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-pattern",
-      "version": "5.0.3-rc.2",
+      "version": "5.0.3",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-pattern",
-  "version": "5.0.3-rc.0",
+  "version": "5.0.3-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-pattern",
-      "version": "5.0.3-rc.0",
+      "version": "5.0.3-rc.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "5.0.2",
+  "version": "5.0.3-rc.0",
   "description": " The exhaustive Pattern Matching library for TypeScript.",
   "type": "module",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "5.0.3-rc.0",
+  "version": "5.0.3-rc.1",
   "description": " The exhaustive Pattern Matching library for TypeScript.",
   "type": "module",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "5.0.3-rc.2",
+  "version": "5.0.3",
   "description": " The exhaustive Pattern Matching library for TypeScript.",
   "type": "module",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "5.0.3-rc.1",
+  "version": "5.0.3-rc.2",
   "description": " The exhaustive Pattern Matching library for TypeScript.",
   "type": "module",
   "source": "src/index.ts",

--- a/src/internals/symbols.ts
+++ b/src/internals/symbols.ts
@@ -22,6 +22,7 @@ export type unset = typeof unset;
 export const isVariadic = Symbol.for('@ts-pattern/isVariadic');
 export type isVariadic = typeof isVariadic;
 
+// can't be a symbol because this key has to be enumerable.
 export const anonymousSelectKey = '@ts-pattern/anonymous-select-key';
 export type anonymousSelectKey = typeof anonymousSelectKey;
 

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -706,13 +706,16 @@ function isInstanceOf<T extends AnyConstructor>(classConstructor: T) {
 }
 
 // These aliases could be inferred, but lead to nicer display names in IDEs.
-type AnyPattern = Chainable<GuardP<unknown, unknown>, never>;
-type StringPattern = StringChainable<GuardP<unknown, string>, never>;
-type NumberPattern = NumberChainable<GuardP<unknown, number>, never>;
-type BooleanPattern = Chainable<GuardP<unknown, boolean>, never>;
-type BigIntPattern = BigIntChainable<GuardP<unknown, bigint>, never>;
-type SymbolPattern = Chainable<GuardP<unknown, symbol>, never>;
-type NullishPattern = Chainable<GuardP<unknown, null | undefined>, never>;
+export type AnyPattern = Chainable<GuardP<unknown, unknown>, never>;
+export type StringPattern = StringChainable<GuardP<unknown, string>, never>;
+export type NumberPattern = NumberChainable<GuardP<unknown, number>, never>;
+export type BooleanPattern = Chainable<GuardP<unknown, boolean>, never>;
+export type BigIntPattern = BigIntChainable<GuardP<unknown, bigint>, never>;
+export type SymbolPattern = Chainable<GuardP<unknown, symbol>, never>;
+export type NullishPattern = Chainable<
+  GuardP<unknown, null | undefined>,
+  never
+>;
 
 /**
  * `P.any` is a wildcard pattern, matching **any value**.

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -32,6 +32,8 @@ import {
   BigIntChainable,
   NumberChainable,
   StringChainable,
+  ArrayChainable,
+  Variadic,
 } from './types/Pattern';
 
 export { Pattern, Fn as unstable_Fn };
@@ -124,8 +126,6 @@ function chainable<pattern extends Matcher<any, any, any, any, any>>(
   }) as Chainable<pattern>;
 }
 
-type Variadic<pattern> = pattern & Iterable<pattern>;
-
 const variadic = <pattern extends {}>(pattern: pattern): Variadic<pattern> =>
   Object.assign(pattern, {
     *[Symbol.iterator]() {
@@ -134,46 +134,6 @@ const variadic = <pattern extends {}>(pattern: pattern): Variadic<pattern> =>
       });
     },
   });
-
-type ArrayChainable<
-  pattern,
-  omitted extends string = never
-> = Variadic<pattern> &
-  Omit<
-    {
-      /**
-       * `.optional()` returns a pattern which matches if the
-       * key is undefined or if it is defined and the previous pattern matches its value.
-       *
-       * [Read the documentation for `P.optional` on GitHub](https://github.com/gvergnaud/ts-pattern#Poptional-patterns)
-       *
-       * @example
-       *  match(value)
-       *   .with({ greeting: P.string.optional() }, () => 'will match { greeting?: string}')
-       */
-      optional<input>(): ArrayChainable<
-        OptionalP<input, pattern>,
-        omitted | 'optional'
-      >;
-      /**
-       * `P.select()` will inject this property into the handler function's arguments.
-       *
-       * [Read the documentation for `P.select` on GitHub](https://github.com/gvergnaud/ts-pattern#Pselect-patterns)
-       *
-       * @example
-       *  match<{ age: number }>(value)
-       *   .with({ age: P.string.select() }, (age) => 'age: number')
-       */
-      select<input>(): ArrayChainable<
-        SelectP<symbols.anonymousSelectKey, input, pattern>,
-        omitted | 'select'
-      >;
-      select<input, k extends string>(
-        key: k
-      ): ArrayChainable<SelectP<k, input, pattern>, omitted | 'select'>;
-    },
-    omitted
-  >;
 
 function arrayChainable<pattern extends Matcher<any, any, any, any, any>>(
   pattern: pattern

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -94,6 +94,19 @@ export type infer<pattern extends Pattern<any>> = InvertPattern<
   unknown
 >;
 
+/**
+ * `P.narrow<Input, Pattern>` will narrow the input type to only keep
+ * the set of values that are compatible with the provided pattern type.
+ *
+ * [Read the documentation for `P.narrow` on GitHub](https://github.com/gvergnaud/ts-pattern#Pnarrow)
+ *
+ * @example
+ * type Input = ['a' | 'b' | 'c', 'a' | 'b' | 'c']
+ * const Pattern = ['a', P.union('a', 'b')] as const
+ *
+ * type Narrowed = P.narrow<Input, typeof Pattern>
+ * //     ^? ['a', 'a' | 'b']
+ */
 export type narrow<input, pattern extends Pattern<any>> = ExtractPreciseValue<
   input,
   InvertPattern<pattern, input>

--- a/src/types/Pattern.ts
+++ b/src/types/Pattern.ts
@@ -608,3 +608,45 @@ export type BigIntChainable<p, omitted extends string = never> = Chainable<
     },
     omitted
   >;
+
+export type Variadic<pattern> = pattern & Iterable<pattern>;
+
+export type ArrayChainable<
+  pattern,
+  omitted extends string = never
+> = Variadic<pattern> &
+  Omit<
+    {
+      /**
+       * `.optional()` returns a pattern which matches if the
+       * key is undefined or if it is defined and the previous pattern matches its value.
+       *
+       * [Read the documentation for `P.optional` on GitHub](https://github.com/gvergnaud/ts-pattern#Poptional-patterns)
+       *
+       * @example
+       *  match(value)
+       *   .with({ greeting: P.string.optional() }, () => 'will match { greeting?: string}')
+       */
+      optional<input>(): ArrayChainable<
+        OptionalP<input, pattern>,
+        omitted | 'optional'
+      >;
+      /**
+       * `P.select()` will inject this property into the handler function's arguments.
+       *
+       * [Read the documentation for `P.select` on GitHub](https://github.com/gvergnaud/ts-pattern#Pselect-patterns)
+       *
+       * @example
+       *  match<{ age: number }>(value)
+       *   .with({ age: P.string.select() }, (age) => 'age: number')
+       */
+      select<input>(): ArrayChainable<
+        SelectP<symbols.anonymousSelectKey, input, pattern>,
+        omitted | 'select'
+      >;
+      select<input, k extends string>(
+        key: k
+      ): ArrayChainable<SelectP<k, input, pattern>, omitted | 'select'>;
+    },
+    omitted
+  >;

--- a/src/types/Pattern.ts
+++ b/src/types/Pattern.ts
@@ -174,3 +174,437 @@ type ArrayPattern<a> = a extends readonly (infer i)[]
         | readonly [Pattern<i>, ...Pattern<i>[]]
         | readonly [...Pattern<i>[], Pattern<i>]
   : never;
+
+// These aliases could be inferred, but lead to nicer display names in IDEs.
+export type AnyPattern = Chainable<GuardP<unknown, unknown>, never>;
+export type StringPattern = StringChainable<GuardP<unknown, string>, never>;
+export type NumberPattern = NumberChainable<GuardP<unknown, number>, never>;
+export type BooleanPattern = Chainable<GuardP<unknown, boolean>, never>;
+export type BigIntPattern = BigIntChainable<GuardP<unknown, bigint>, never>;
+export type SymbolPattern = Chainable<GuardP<unknown, symbol>, never>;
+export type NullishPattern = Chainable<
+  GuardP<unknown, null | undefined>,
+  never
+>;
+
+type MaybeAnd<omitted, input, p1, p2> = [omitted] extends [never]
+  ? p2
+  : AndP<input, [p1, p2]>;
+
+export type Chainable<p, omitted extends string = never> = p &
+  Omit<
+    {
+      /**
+       * `.optional()` returns a pattern which matches if the
+       * key is undefined or if it is defined and the previous pattern matches its value.
+       *
+       * [Read the documentation for `P.optional` on GitHub](https://github.com/gvergnaud/ts-pattern#Poptional-patterns)
+       *
+       * @example
+       *  match(value)
+       *   .with({ greeting: P.string.optional() }, () => 'will match { greeting?: string}')
+       */
+      optional<input>(): Chainable<OptionalP<input, p>, omitted | 'optional'>;
+      /**
+       * `pattern.and(pattern)` returns a pattern that matches
+       * if the previous pattern and the next one match the input.
+       *
+       * [Read the documentation for `P.intersection` on GitHub](https://github.com/gvergnaud/ts-pattern#Pintersection-patterns)
+       *
+       * @example
+       *  match(value)
+       *   .with(
+       *     P.string.and(P.when(isUsername)),
+       *     (username) => '...'
+       *   )
+       */
+      and<input, p2 extends Pattern<input>>(
+        pattern: p2
+      ): Chainable<AndP<input, [p, p2]>, omitted>;
+      /**
+       * `pattern.or(pattern)` returns a pattern that matches
+       * if **either** the previous pattern or the next one match the input.
+       *
+       * [Read the documentation for `P.union` on GitHub](https://github.com/gvergnaud/ts-pattern#Punion-patterns)
+       *
+       * @example
+       *  match(value)
+       *   .with(
+       *     { value: P.string.or(P.number) },
+       *     ({ value }) => 'value: number | string'
+       *   )
+       */
+      or<input, p2 extends Pattern<input>>(
+        pattern: p2
+      ): Chainable<OrP<input, [p, p2]>, omitted>;
+      /**
+       * `P.select()` will inject this property into the handler function's arguments.
+       *
+       * [Read the documentation for `P.select` on GitHub](https://github.com/gvergnaud/ts-pattern#Pselect-patterns)
+       *
+       * @example
+       *  match<{ age: number }>(value)
+       *   .with({ age: P.string.select() }, (age) => 'age: number')
+       */
+      select<input>(): Chainable<
+        SelectP<symbols.anonymousSelectKey, input, p>,
+        omitted | 'select' | 'or' | 'and'
+      >;
+      select<input, k extends string>(
+        key: k
+      ): Chainable<SelectP<k, input, p>, omitted | 'select' | 'or' | 'and'>;
+    },
+    omitted
+  >;
+
+export type StringChainable<
+  p extends Matcher<any, any, any, any, any>,
+  omitted extends string = never
+> = Chainable<p, omitted> &
+  Omit<
+    {
+      /**
+       * `P.string.startsWith(start)` is a pattern, matching **strings** starting with `start`.
+       *
+       * [Read the documentation for `P.string.startsWith` on GitHub](https://github.com/gvergnaud/ts-pattern#PstringstartsWith)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.string.startsWith('A'), () => 'value starts with an A')
+       */
+      startsWith<input, const start extends string>(
+        start: start
+      ): StringChainable<
+        MaybeAnd<omitted, input, p, GuardP<input, `${start}${string}`>>,
+        omitted | 'startsWith'
+      >;
+      /**
+       * `P.string.endsWith(end)` is a pattern, matching **strings** ending with `end`.
+       *
+       * [Read the documentation for `P.string.endsWith` on GitHub](https://github.com/gvergnaud/ts-pattern#PstringendsWith)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.string.endsWith('!'), () => 'value ends with an !')
+       */
+      endsWith<input, const end extends string>(
+        end: end
+      ): StringChainable<
+        MaybeAnd<omitted, input, p, GuardP<input, `${string}${end}`>>,
+        omitted | 'endsWith'
+      >;
+      /**
+       * `P.string.minLength(min)` is a pattern, matching **strings** with at least `min` characters.
+       *
+       * [Read the documentation for `P.string.minLength` on GitHub](https://github.com/gvergnaud/ts-pattern#PstringminLength)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.string.minLength(10), () => 'string with more length <= 10')
+       */
+      minLength<input, const min extends number>(
+        min: min
+      ): StringChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, string, never>>,
+        omitted | 'minLength'
+      >;
+      /**
+       * `P.string.maxLength(max)` is a pattern, matching **strings** with at most `max` characters.
+       *
+       * [Read the documentation for `P.string.maxLength` on GitHub](https://github.com/gvergnaud/ts-pattern#PstringmaxLength)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.string.maxLength(10), () => 'string with more length >= 10')
+       */
+      maxLength<input, const max extends number>(
+        max: max
+      ): StringChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, string, never>>,
+        omitted | 'maxLength'
+      >;
+      /**
+       * `P.string.includes(substr)` is a pattern, matching **strings** containing `substr`.
+       *
+       * [Read the documentation for `P.string.includes` on GitHub](https://github.com/gvergnaud/ts-pattern#Pstringincludes)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.string.includes('http'), () => 'value contains http')
+       */
+      includes<input, const substr extends string>(
+        substr: substr
+      ): StringChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, string, never>>,
+        omitted
+      >;
+      /**
+       * `P.string.regex(expr)` is a pattern, matching **strings** that `expr` regular expression.
+       *
+       * [Read the documentation for `P.string.regex` on GitHub](https://github.com/gvergnaud/ts-pattern#Pstringregex)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.string.regex(/^https?:\/\//), () => 'url')
+       */
+      regex<input, const expr extends string | RegExp>(
+        expr: expr
+      ): StringChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, string, never>>,
+        omitted
+      >;
+    },
+    omitted
+  >;
+
+export type NumberChainable<p, omitted extends string = never> = Chainable<
+  p,
+  omitted
+> &
+  Omit<
+    {
+      /**
+       * `P.number.between(min, max)` matches **number** between `min` and `max`,
+       * equal to min or equal to max.
+       *
+       * [Read the documentation for `P.number.between` on GitHub](https://github.com/gvergnaud/ts-pattern#Pnumberbetween)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.number.between(0, 10), () => '0 <= numbers <= 10')
+       */
+      between<input, const min extends number, const max extends number>(
+        min: min,
+        max: max
+      ): NumberChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, number, never>>,
+        omitted
+      >;
+      /**
+       * `P.number.lt(max)` matches **number** smaller than `max`.
+       *
+       * [Read the documentation for `P.number.lt` on GitHub](https://github.com/gvergnaud/ts-pattern#Pnumberlt)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.number.lt(10), () => 'numbers < 10')
+       */
+      lt<input, const max extends number>(
+        max: max
+      ): NumberChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, number, never>>,
+        omitted
+      >;
+      /**
+       * `P.number.gt(min)` matches **number** greater than `min`.
+       *
+       * [Read the documentation for `P.number.gt` on GitHub](https://github.com/gvergnaud/ts-pattern#Pnumbergt)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.number.gt(10), () => 'numbers > 10')
+       */
+      gt<input, const min extends number>(
+        min: min
+      ): NumberChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, number, never>>,
+        omitted
+      >;
+      /**
+       * `P.number.lte(max)` matches **number** smaller than or equal to `max`.
+       *
+       * [Read the documentation for `P.number.lte` on GitHub](https://github.com/gvergnaud/ts-pattern#Pnumberlte)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.number.lte(10), () => 'numbers <= 10')
+       */
+      lte<input, const max extends number>(
+        max: max
+      ): NumberChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, number, never>>,
+        omitted
+      >;
+      /**
+       * `P.number.gte(min)` matches **number** greater than or equal to `min`.
+       *
+       * [Read the documentation for `P.number.gte` on GitHub](https://github.com/gvergnaud/ts-pattern#Pnumbergte)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.number.gte(10), () => 'numbers >= 10')
+       */
+      gte<input, const min extends number>(
+        min: min
+      ): NumberChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, number, never>>,
+        omitted
+      >;
+      /**
+       * `P.number.int` matches **integer** numbers.
+       *
+       * [Read the documentation for `P.number.int` on GitHub](https://github.com/gvergnaud/ts-pattern#Pnumberint)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.number.int, () => 'an integer')
+       */
+      int<input>(): NumberChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, number, never>>,
+        omitted | 'int'
+      >;
+      /**
+       * `P.number.finite` matches **finite numbers**.
+       *
+       * [Read the documentation for `P.number.finite` on GitHub](https://github.com/gvergnaud/ts-pattern#Pnumberfinite)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.number.finite, () => 'not Infinity')
+       */
+      finite<input>(): NumberChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, number, never>>,
+        omitted | 'finite'
+      >;
+      /**
+       * `P.number.positive` matches **positive** numbers.
+       *
+       * [Read the documentation for `P.number.positive` on GitHub](https://github.com/gvergnaud/ts-pattern#Pnumberpositive)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.number.positive, () => 'number > 0')
+       */
+      positive<input>(): NumberChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, number, never>>,
+        omitted | 'positive' | 'negative'
+      >;
+      /**
+       * `P.number.negative` matches **negative** numbers.
+       *
+       * [Read the documentation for `P.number.negative` on GitHub](https://github.com/gvergnaud/ts-pattern#Pnumbernegative)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.number.negative, () => 'number < 0')
+       */
+      negative<input>(): NumberChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, number, never>>,
+        omitted | 'positive' | 'negative' | 'negative'
+      >;
+    },
+    omitted
+  >;
+
+export type BigIntChainable<p, omitted extends string = never> = Chainable<
+  p,
+  omitted
+> &
+  Omit<
+    {
+      /**
+       * `P.bigint.between(min, max)` matches **bigint** between `min` and `max`,
+       * equal to min or equal to max.
+       *
+       * [Read the documentation for `P.bigint.between` on GitHub](https://github.com/gvergnaud/ts-pattern#Pnumberbetween)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.bigint.between(0, 10), () => '0 <= numbers <= 10')
+       */
+      between<input, const min extends bigint, const max extends bigint>(
+        min: min,
+        max: max
+      ): BigIntChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, bigint, never>>,
+        omitted
+      >;
+      /**
+       * `P.bigint.lt(max)` matches **bigint** smaller than `max`.
+       *
+       * [Read the documentation for `P.bigint.lt` on GitHub](https://github.com/gvergnaud/ts-pattern#bigintlt)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.bigint.lt(10), () => 'numbers < 10')
+       */
+      lt<input, const max extends bigint>(
+        max: max
+      ): BigIntChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, bigint, never>>,
+        omitted
+      >;
+      /**
+       * `P.bigint.gt(min)` matches **bigint** greater than `min`.
+       *
+       * [Read the documentation for `P.bigint.gt` on GitHub](https://github.com/gvergnaud/ts-pattern#bigintgt)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.bigint.gt(10), () => 'numbers > 10')
+       */
+      gt<input, const min extends bigint>(
+        min: min
+      ): BigIntChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, bigint, never>>,
+        omitted
+      >;
+      /**
+       * `P.bigint.lte(max)` matches **bigint** smaller than or equal to `max`.
+       *
+       * [Read the documentation for `P.bigint.lte` on GitHub](https://github.com/gvergnaud/ts-pattern#bigintlte)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.bigint.lte(10), () => 'bigints <= 10')
+       */
+      lte<input, const max extends bigint>(
+        max: max
+      ): BigIntChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, bigint, never>>,
+        omitted
+      >;
+      /**
+       * `P.bigint.gte(min)` matches **bigint** greater than or equal to `min`.
+       *
+       * [Read the documentation for `P.bigint.gte` on GitHub](https://github.com/gvergnaud/ts-pattern#Pnumbergte)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.bigint.gte(10), () => 'bigints >= 10')
+       */
+      gte<input, const min extends bigint>(
+        min: min
+      ): BigIntChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, bigint, never>>,
+        omitted
+      >;
+      /**
+       * `P.bigint.positive` matches **positive** bigints.
+       *
+       * [Read the documentation for `P.bigint.positive` on GitHub](https://github.com/gvergnaud/ts-pattern#Pnumberpositive)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.bigint.positive, () => 'bigint > 0')
+       */
+      positive<input>(): BigIntChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, bigint, never>>,
+        omitted | 'positive' | 'negative'
+      >;
+      /**
+       * `P.bigint.negative` matches **negative** bigints.
+       *
+       * [Read the documentation for `P.bigint.negative` on GitHub](https://github.com/gvergnaud/ts-pattern#Pnumbernegative)
+       *
+       * @example
+       *  match(value)
+       *   .with(P.bigint.negative, () => 'bigint < 0')
+       */
+      negative<input>(): BigIntChainable<
+        MaybeAnd<omitted, input, p, GuardExcludeP<input, bigint, never>>,
+        omitted | 'positive' | 'negative' | 'negative'
+      >;
+    },
+    omitted
+  >;

--- a/tests/narrow.test.ts
+++ b/tests/narrow.test.ts
@@ -1,0 +1,13 @@
+import { P } from '../src';
+import { Equal, Expect } from '../src/types/helpers';
+
+describe('P.infer', () => {
+  it('should correctly narrow the input type', () => {
+    type Input = ['a' | 'b' | 'c', 'a' | 'b' | 'c'];
+    const Pattern = ['a', P.union('a', 'b')] as const;
+
+    type Narrowed = P.narrow<Input, typeof Pattern>;
+    //     ^?
+    type test = Expect<Equal<Narrowed, ['a', 'a' | 'b']>>;
+  });
+});

--- a/tests/narrow.test.ts
+++ b/tests/narrow.test.ts
@@ -1,7 +1,7 @@
 import { P } from '../src';
 import { Equal, Expect } from '../src/types/helpers';
 
-describe('P.infer', () => {
+describe('P.narrow', () => {
   it('should correctly narrow the input type', () => {
     type Input = ['a' | 'b' | 'c', 'a' | 'b' | 'c'];
     const Pattern = ['a', P.union('a', 'b')] as const;


### PR DESCRIPTION
This PR fixes issue https://github.com/gvergnaud/ts-pattern/issues/174, reporting that It's currently impossible re-export a pattern from an ES module due to the following TS error:

```
The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed.(7056)
```

The compiler currently tries to inline pattern types when generating type definitions for a module exporting a TS-Pattern pattern, but since these types can get pretty large, it stops inlining them after a char count threshold has been crossed. Here is a [Playground](https://www.typescriptlang.org/play?ts=5.0.4#code/JYWwDg9gTgLgBAbziAhjAxgCwDRwApwC+cAZlBCHAOQwDOAtGGjAKZQB2VA3HAPS9wYATzAtaALjgA3AKwA6AAxyAjAChV6CO1rxgtAGIQIyuAF58cnVGDsA5nwGBQcnWbtu2gCEUUE+aQpJACIUQNwAI0k8SxhrOyI4FFo4Vx0HOGdVFgAPSFhkrVS9QwgAJjMLKxt7fjhAGXJ1bNz4FPcvKDK-BKCQ8Mjo2PtiRPy3NNqgA) Reproducing the issue.

Moving pattern type helpers to a separate module and exporting them fixes the issue, because the compiler is able to resolve these type helpers instead of inlining these types. as you can see in [This Playground](https://www.typescriptlang.org/play?ts=5.0.4#code/JYWwDg9gTgLgBAbziAhjAxgCwDRwApwC+cAZlBCHAOQwDOAtGGjAKZQB2VA3HAPS9wYATzAtaALjgA3AKwA6AAxyAzPSjo5AJgBQ29BHa14wWgDEIEAIxwAvPjlGowdgHM+AwKDku-YeO0AQihQ1nZIKJIARCgRuABGkngOME6uRHAotHA+Ru5wXtosAB6QsFkGOSbmEJq29o7ObvxwgDLkukUl8Nl+gVA1oemR0XEJSSluxBllvrnNQA), the issue is fixed.