### PR TITLE
🐛 fix: Accept branded primitive types as patterns

### DIFF
--- a/src/types/Pattern.ts
+++ b/src/types/Pattern.ts
@@ -158,7 +158,7 @@ type KnownPatternInternal<
   a,
   objs = Exclude<a, Primitives | Map<any, any> | Set<any> | readonly any[]>,
   arrays = Extract<a, readonly any[]>,
-  primitives = Exclude<a, object>
+  primitives = Extract<a, Primitives>
 > =
   | primitives
   | PatternMatcher<a>

--- a/tests/branded-nominal-types.test.ts
+++ b/tests/branded-nominal-types.test.ts
@@ -23,4 +23,38 @@ describe('Branded strings', () => {
         .otherwise(() => 'nope')
     ).toEqual('Match: value');
   });
+
+  it('issue #167', () => {
+    const tag: unique symbol = Symbol();
+    type Tagged<Token> = { readonly [tag]: Token };
+    type Opaque<Type, Token = unknown> = Type & Tagged<Token>;
+
+    const opaqueString = (Math.random() > 0.5 ? 'A' : 'B') as Opaque<'A' | 'B'>;
+
+    match(opaqueString)
+      .with('A' as Opaque<'A'>, () => 1)
+      .with('B' as Opaque<'B'>, () => 2)
+      .exhaustive();
+  });
+
+  it('issue #178', () => {
+    const symbol: unique symbol = Symbol();
+
+    interface Branded<key extends string> {
+      [symbol]: { [k in key]: true };
+    }
+
+    type Brand<a, key extends string> = a & Branded<key>;
+    type BrandId = Brand<number, 'BrandId'>;
+
+    const a: number = 1;
+    const b: BrandId = 1 as BrandId;
+
+    expect(
+      match({ a, b })
+        .with({ a, b }, () => '1')
+        .with({ a: P.number, b: P.number }, () => '2')
+        .exhaustive()
+    ).toEqual('1');
+  });
 });


### PR DESCRIPTION
TS-Pattern v4 used to support branded types, usually defined as an intersection between a literal type (like `number` or `string`) and an object containing a unique symbol. There is a bug in v5 that prevents people from using branded types as patterns and this PR fixes it.

This closes issue #167 and #178.