### PR TITLE
export PatternMatcher type to better support custom matchers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import * as Pattern from './patterns';
 
+export type { PatternMatcher } from './types/Pattern'
+
 export { match } from './match';
 export { isMatching } from './is-matching';
 export { Pattern, Pattern as P };

--- a/src/types/Pattern.ts
+++ b/src/types/Pattern.ts
@@ -72,7 +72,7 @@ export interface Matcher<
   [symbols.isVariadic]?: boolean;
 }
 
-type PatternMatcher<input> = Matcher<input, unknown, any, any>;
+export type PatternMatcher<input> = Matcher<input, unknown, any, any>;
 
 // We fall back to `a` if we weren't able to extract anything more precise
 export type MatchedValue<a, invpattern> = WithDefault<


### PR DESCRIPTION
Taking inspiration from this PR: https://github.com/gvergnaud/ts-pattern/pull/45

It seems like the only thing needed to make that PR easily done in userland is exporting this one type.