### PR TITLE
fix: Make sure regeneratorRuntime isn't included in the cjs build

### DIFF
--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -128,10 +128,18 @@ function chainable<pattern extends Matcher<any, any, any, any, any>>(
 
 const variadic = <pattern extends {}>(pattern: pattern): Variadic<pattern> =>
   Object.assign(pattern, {
-    *[Symbol.iterator]() {
-      yield Object.assign(pattern, {
+    [Symbol.iterator](): Iterator<pattern, void, undefined> {
+      let i = 0;
+      const variadicPattern = Object.assign(pattern, {
         [symbols.isVariadic]: true,
       });
+      const values: IteratorResult<pattern, void>[] = [
+        { value: variadicPattern, done: false },
+        { done: true, value: undefined },
+      ];
+      return {
+        next: () => values[i++] ?? values.at(-1)!,
+      };
     },
   });
 


### PR DESCRIPTION
The CJS build of TS-Pattern generates es5 javascript code, and turns the generator syntax into `regeneratorRuntime` calls, a function that's part of Babel's standard library:

```ts
(((t = {})[Symbol.iterator] = function () {
          /*#__PURE__*/ return regeneratorRuntime.mark(function t() {
            var r;
            return regeneratorRuntime.wrap(function (t) {
              // ...
            }, t);
          })();
        }),
```

The issue is that there is no guarantee that this function is in scope where TS-Pattern's CJS build is executed. This is a microbundle bug that has a closed issue here: https://github.com/developit/microbundle/issues/708 it's supposedly fixed, but I still see this behavior with the latest version of micro bundle, so this PR just turns the only generator of TS-Pattern into an iterator object.