### PR TITLE
feat: Add P.nonNullable patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -792,14 +792,14 @@ type Input =
   | [number, '*', number]
   | ['-', number];
 
-const input: Input = [3, '*', 4];
+const input = [3, '*', 4] as Input;
 
 const output = match(input)
   .with([P._, '+', P._], ([x, , y]) => x + y)
   .with([P._, '-', P._], ([x, , y]) => x - y)
   .with([P._, '*', P._], ([x, , y]) => x * y)
   .with(['-', P._], ([, x]) => -x)
-  .otherwise(() => NaN);
+  .exhaustive();
 
 console.log(output);
 // => 12

--- a/README.md
+++ b/README.md
@@ -896,9 +896,24 @@ const input = null;
 const output = match<number | null | undefined>(input)
   .with(P.number, () => 'it is a number!')
   .with(P.nullish, () => 'it is either null or undefined!')
-  .with(null, () => 'it is null!')
-  .with(undefined, () => 'it is undefined!')
   .exhaustive();
+
+console.log(output);
+// => 'it is either null or undefined!'
+```
+
+#### `P.nonNullable` wildcard
+
+The `P.nonNullable` pattern will match any value except `null` or `undefined`.
+
+```ts
+import { match, P } from 'ts-pattern';
+
+const input = null;
+
+const output = match<number | null | undefined>(input)
+  .with(P.nonNullable, () => 'it is a number!')
+  .otherwise(() => 'it is either null or undefined!');
 
 console.log(output);
 // => 'it is either null or undefined!'

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,5 +1,8 @@
 ### Roadmap
 
+- [ ] `P.array.includes(x)`
+- [ ] `P.record({Pkey}, {Pvalue})`
+- [x] `P.nonNullable`
 - [x] chainable methods
   - [x] string
     - [x] `P.string.includes('str')`

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -34,6 +34,7 @@ import {
   StringChainable,
   ArrayChainable,
   Variadic,
+  NonNullablePattern,
 } from './types/Pattern';
 
 export type { Pattern, Fn as unstable_Fn };
@@ -634,6 +635,10 @@ function isNullish<T>(x: T | null | undefined): x is null | undefined {
   return x === null || x === undefined;
 }
 
+function doesExists(x: unknown): x is {} {
+  return x !== null && x !== undefined;
+}
+
 type AnyConstructor = abstract new (...args: any[]) => any;
 
 function isInstanceOf<T extends AnyConstructor>(classConstructor: T) {
@@ -1075,6 +1080,16 @@ export const symbol: SymbolPattern = chainable(when(isSymbol));
  *   .with(P.nullish, () => 'will match on null or undefined')
  */
 export const nullish: NullishPattern = chainable(when(isNullish));
+
+/**
+ * `P.nonNullable` is a wildcard pattern, matching everything except **null** or **undefined**.
+ *
+ * [Read the documentation for `P.nonNullable` on GitHub](https://github.com/gvergnaud/ts-pattern#nonNullable-wildcard)
+ *
+ * @example
+ *   .with(P.nonNullable, () => 'will match on null or undefined')
+ */
+export const nonNullable: NonNullablePattern = chainable(when(doesExists));
 
 /**
  * `P.instanceOf(SomeClass)` is a pattern matching instances of a given class.

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -933,7 +933,7 @@ export const number: NumberPattern = numberChainable(when(isNumber));
  *
  * @example
  *  match(value)
- *   .with(P.bigint.between(0, 10), () => '0 <= numbers <= 10')
+ *   .with(P.bigint.between(0, 10), () => '0 <= bigints <= 10')
  */
 const betweenBigInt = <
   input,
@@ -952,7 +952,7 @@ const betweenBigInt = <
  *
  * @example
  *  match(value)
- *   .with(P.bigint.lt(10), () => 'numbers < 10')
+ *   .with(P.bigint.lt(10), () => 'bigints < 10')
  */
 const ltBigInt = <input, const max extends bigint>(
   max: max
@@ -966,7 +966,7 @@ const ltBigInt = <input, const max extends bigint>(
  *
  * @example
  *  match(value)
- *   .with(P.bigint.gt(10), () => 'numbers > 10')
+ *   .with(P.bigint.gt(10), () => 'bigints > 10')
  */
 const gtBigInt = <input, const min extends bigint>(
   min: min
@@ -1077,7 +1077,7 @@ export const symbol: SymbolPattern = chainable(when(isSymbol));
  * [Read the documentation for `P.nullish` on GitHub](https://github.com/gvergnaud/ts-pattern#nullish-wildcard)
  *
  * @example
- *   .with(P.nullish, () => 'will match on null or undefined')
+ *   .with(P.nullish, (x) => `${x} is null or undefined`)
  */
 export const nullish: NullishPattern = chainable(when(isNullish));
 
@@ -1087,7 +1087,7 @@ export const nullish: NullishPattern = chainable(when(isNullish));
  * [Read the documentation for `P.nonNullable` on GitHub](https://github.com/gvergnaud/ts-pattern#nonNullable-wildcard)
  *
  * @example
- *   .with(P.nonNullable, () => 'will match on null or undefined')
+ *   .with(P.nonNullable, (x) => `${x} isn't null nor undefined`)
  */
 export const nonNullable: NonNullablePattern = chainable(when(isNonNullable));
 

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -635,7 +635,7 @@ function isNullish<T>(x: T | null | undefined): x is null | undefined {
   return x === null || x === undefined;
 }
 
-function doesExists(x: unknown): x is {} {
+function isNonNullable(x: unknown): x is {} {
   return x !== null && x !== undefined;
 }
 
@@ -1089,7 +1089,7 @@ export const nullish: NullishPattern = chainable(when(isNullish));
  * @example
  *   .with(P.nonNullable, () => 'will match on null or undefined')
  */
-export const nonNullable: NonNullablePattern = chainable(when(doesExists));
+export const nonNullable: NonNullablePattern = chainable(when(isNonNullable));
 
 /**
  * `P.instanceOf(SomeClass)` is a pattern matching instances of a given class.

--- a/src/types/Pattern.ts
+++ b/src/types/Pattern.ts
@@ -1,12 +1,7 @@
 import type * as symbols from '../internals/symbols';
-import {
-  LeastUpperBound,
-  MergeUnion,
-  Primitives,
-  WithDefault,
-} from './helpers';
+import { MergeUnion, Primitives, WithDefault } from './helpers';
 import { None, Some, SelectionType } from './FindSelected';
-import { matcher, narrow } from '../patterns';
+import { matcher } from '../patterns';
 import { ExtractPreciseValue } from './ExtractPreciseValue';
 
 export type MatcherType =
@@ -191,6 +186,8 @@ export type NullishPattern = Chainable<
   GuardP<unknown, null | undefined>,
   never
 >;
+
+export type NonNullablePattern = Chainable<GuardP<unknown, {}>, never>;
 
 type MergeGuards<input, guard1, guard2> = [guard1, guard2] extends [
   GuardExcludeP<any, infer narrowed1, infer excluded1>,

--- a/tests/wildcards.test.ts
+++ b/tests/wildcards.test.ts
@@ -57,19 +57,21 @@ describe('wildcards', () => {
   });
 
   it('should match nonNullable wildcard', () => {
-    const res = match<string | number | boolean | null | undefined>(null)
+    type Input = string | number | boolean | null | undefined;
+    const res = match<Input>(false)
       .with(P.nonNullable, (x) => {
         type t = Expect<Equal<typeof x, string | number | boolean>>;
         return true;
       })
       .otherwise(() => false);
 
-    const res2 = match<string | number | boolean | null | undefined>(undefined)
+    const res2 = match<0 | 1 | 2 | null>(0)
       .with(P.nonNullable, (x) => {
-        type t = Expect<Equal<typeof x, string | number | boolean>>;
+        type t = Expect<Equal<typeof x, 0 | 1 | 2>>;
         return true;
       })
-      .otherwise(() => false);
+      .with(null, () => false)
+      .exhaustive();
 
     expect(res).toEqual(true);
     expect(res2).toEqual(true);

--- a/tests/wildcards.test.ts
+++ b/tests/wildcards.test.ts
@@ -56,6 +56,25 @@ describe('wildcards', () => {
     expect(res2).toEqual(true);
   });
 
+  it('should match nonNullable wildcard', () => {
+    const res = match<string | number | boolean | null | undefined>(null)
+      .with(P.nonNullable, (x) => {
+        type t = Expect<Equal<typeof x, string | number | boolean>>;
+        return true;
+      })
+      .otherwise(() => false);
+
+    const res2 = match<string | number | boolean | null | undefined>(undefined)
+      .with(P.nonNullable, (x) => {
+        type t = Expect<Equal<typeof x, string | number | boolean>>;
+        return true;
+      })
+      .otherwise(() => false);
+
+    expect(res).toEqual(true);
+    expect(res2).toEqual(true);
+  });
+
   it('should match String, Number and Boolean wildcards', () => {
     // Will be { id: number, title: string } | { errorMessage: string }
     let httpResult = {


### PR DESCRIPTION
## `P.nonNullable` wildcard

Add a new `P.nonNullable` pattern that will match any value except `null` or `undefined`.

```ts
import { match, P } from 'ts-pattern';

const input = null;

const output = match<number | null | undefined>(input)
  .with(P.nonNullable, () => 'it is a number!')
  .otherwise(() => 'it is either null or undefined!');

console.log(output);
// => 'it is either null or undefined!'
```

Closes #60 #154 #190 and will be a work-around for #143.