### PR TITLE
Add P.object and P.object.empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1497,7 +1497,7 @@ const fn = (input: string) =>
     .with(P.object.empty(), () => 'Empty!')
     .otherwise(() => 'Full!');
 
-console.log(fn('{}')); // Empty
+console.log(fn({})); // Empty!
 ```
 
 ## Types

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ TS-Pattern assumes that [Strict Mode](https://www.typescriptlang.org/tsconfig#st
     - [`P.intersection` patterns](#pintersection-patterns)
     - [`P.string` predicates](#pstring-predicates)
     - [`P.number` and `P.bigint` predicates](#pnumber-and-pbigint-predicates)
+    - [`P.object` predicates](#pobject-predicates)
   - [Types](#types)
     - [`P.infer`](#pinfer)
     - [`P.Pattern`](#pPattern)
@@ -1480,6 +1481,23 @@ const fn = (input: number) =>
     .otherwise(() => '❌');
 
 console.log(fn(-3.141592), fn(7)); // logs '✅ ❌'
+```
+
+## `P.object` predicates
+
+`P.object` has a number of methods to help you match on specific object.
+
+### `P.object.empty`
+
+`P.object.empty` matches empty object
+
+```ts
+const fn = (input: string) =>
+  match(input)
+    .with(P.object.empty(), () => 'Empty!')
+    .otherwise(() => 'Full!');
+
+console.log(fn('{}')); // Empty
 ```
 
 ## Types

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -34,6 +34,7 @@ import {
   StringChainable,
   ArrayChainable,
   Variadic,
+  ObjectChainable,
 } from './types/Pattern';
 
 export type { Pattern, Fn as unstable_Fn };
@@ -634,6 +635,12 @@ function isNullish<T>(x: T | null | undefined): x is null | undefined {
   return x === null || x === undefined;
 }
 
+function isObject<T>(x: T | object): x is object {
+  return typeof x === 'object' &&
+  !Array.isArray(x) &&
+  x !== null
+}
+
 type AnyConstructor = abstract new (...args: any[]) => any;
 
 function isInstanceOf<T extends AnyConstructor>(classConstructor: T) {
@@ -1110,3 +1117,35 @@ export function shape<input, const pattern extends Pattern<input>>(
 export function shape(pattern: UnknownPattern) {
   return chainable(when(isMatching(pattern)));
 }
+
+/**
+ * `P.object.empty()` is a pattern, matching **objects** with no keys.
+ *
+ * [Read the documentation for `P.object.empty` on GitHub](https://github.com/gvergnaud/ts-pattern#pobjectempty)
+ *
+ * @example
+ *  match(value)
+ *   .with(P.object.empty(), () => 'will match on empty objects')
+ */
+const emptyObject = <input>(): GuardExcludeP<input, object, never> => when(
+    (value) => value && typeof value === 'object' && Object.keys(value).length === 0,
+  );
+
+const objectChainable = <pattern extends Matcher<any, any, any, any, any>>(
+  pattern: pattern
+): ObjectChainable<pattern> =>
+  Object.assign(chainable(pattern), {
+    empty: () => objectChainable(intersection(pattern, emptyObject())),
+  }) as any;
+
+/**
+ * `P.object` is a wildcard pattern, matching any **object**.
+ * It lets you call methods like `.empty()`, `.and`, `.or` and `.select()`
+ * On structural patterns, like objects and arrays.
+ * [Read the documentation for `P.object` on GitHub](https://github.com/gvergnaud/ts-pattern#pobject-predicates)
+ * 
+ * @example 
+ * match(value)
+ *  .with(P.object.empty(), () => 'will match on empty objects')
+ **/
+export const object: ObjectChainable<any> = objectChainable(when(isObject));

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -1138,7 +1138,7 @@ const emptyObject = <input>(): GuardExcludeP<input, object, never> => when(
 
 const objectChainable = <pattern extends Matcher<any, any, any, any, any>>(
   pattern: pattern
-): ObjectChainable<pattern> =>
+): ObjectChainable<pattern> => 
   Object.assign(chainable(pattern), {
     empty: () => chainable(intersection(pattern, emptyObject())),
   }) as any;
@@ -1153,4 +1153,4 @@ const objectChainable = <pattern extends Matcher<any, any, any, any, any>>(
  * match(value)
  *  .with(P.object.empty(), () => 'will match on empty objects')
  **/
-export const object: ObjectChainable<any> = objectChainable(when(isObject));
+export const object: ObjectChainable<GuardP<unknown, object>> = objectChainable(when(isObject));

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -1128,14 +1128,19 @@ export function shape(pattern: UnknownPattern) {
  *   .with(P.object.empty(), () => 'will match on empty objects')
  */
 const emptyObject = <input>(): GuardExcludeP<input, object, never> => when(
-    (value) => value && typeof value === 'object' && Object.keys(value).length === 0,
+    (value) => {
+      if (!isObject(value)) return false;
+
+      for (var prop in value) return false;
+      return true;
+    },
   );
 
 const objectChainable = <pattern extends Matcher<any, any, any, any, any>>(
   pattern: pattern
 ): ObjectChainable<pattern> =>
   Object.assign(chainable(pattern), {
-    empty: () => objectChainable(intersection(pattern, emptyObject())),
+    empty: () => chainable(intersection(pattern, emptyObject())),
   }) as any;
 
 /**

--- a/src/types/Pattern.ts
+++ b/src/types/Pattern.ts
@@ -15,6 +15,7 @@ export type MatcherType =
   | 'or'
   | 'and'
   | 'array'
+  | 'object'
   | 'map'
   | 'set'
   | 'select'
@@ -96,6 +97,8 @@ export type CustomP<input, pattern, narrowedOrFn> = Matcher<
 >;
 
 export type ArrayP<input, p> = Matcher<input, p, 'array'>;
+
+export type ObjectP<input, p> = Matcher<input, p, 'object'>;
 
 export type OptionalP<input, p> = Matcher<input, p, 'optional'>;
 
@@ -191,7 +194,6 @@ export type NullishPattern = Chainable<
   GuardP<unknown, null | undefined>,
   never
 >;
-
 type MergeGuards<input, guard1, guard2> = [guard1, guard2] extends [
   GuardExcludeP<any, infer narrowed1, infer excluded1>,
   GuardExcludeP<any, infer narrowed2, infer excluded2>
@@ -655,6 +657,29 @@ export type ArrayChainable<
       select<input, k extends string>(
         key: k
       ): ArrayChainable<SelectP<k, input, pattern>, omitted | 'select'>;
+    },
+    omitted
+  >;
+
+export type ObjectChainable<
+  pattern,
+  omitted extends string = never
+> = Chainable<pattern, omitted> &
+  Omit<
+    {
+      /**
+       * `.empty()` matches an empty object.
+       *
+       * [Read the documentation for `P.object.empty` on GitHub](https://github.com/gvergnaud/ts-pattern#pobjectempty)
+       *
+       * @example
+       * match(value)
+       *  .with(P.object.empty(), () => 'empty object')
+       */
+      empty<input>(): ObjectChainable<
+        ObjectP<input, Record<string, never>>,
+        omitted | 'empty'
+      >;
     },
     omitted
   >;

--- a/src/types/Pattern.ts
+++ b/src/types/Pattern.ts
@@ -677,9 +677,9 @@ export type ObjectChainable<
        *  .with(P.object.empty(), () => 'empty object')
        */
       empty<input>(): Chainable<
-        ObjectP<input, Record<string, never>>,
+        GuardExcludeP<input, {}, never>,
         omitted | 'empty'
-      >;
+    >;
     },
     omitted
   >;

--- a/src/types/Pattern.ts
+++ b/src/types/Pattern.ts
@@ -15,7 +15,6 @@ export type MatcherType =
   | 'or'
   | 'and'
   | 'array'
-  | 'object'
   | 'map'
   | 'set'
   | 'select'
@@ -98,7 +97,7 @@ export type CustomP<input, pattern, narrowedOrFn> = Matcher<
 
 export type ArrayP<input, p> = Matcher<input, p, 'array'>;
 
-export type ObjectP<input, p> = Matcher<input, p, 'object'>;
+export type ObjectP<input, p> = Matcher<input, p>;
 
 export type OptionalP<input, p> = Matcher<input, p, 'optional'>;
 
@@ -194,6 +193,7 @@ export type NullishPattern = Chainable<
   GuardP<unknown, null | undefined>,
   never
 >;
+
 type MergeGuards<input, guard1, guard2> = [guard1, guard2] extends [
   GuardExcludeP<any, infer narrowed1, infer excluded1>,
   GuardExcludeP<any, infer narrowed2, infer excluded2>
@@ -676,7 +676,7 @@ export type ObjectChainable<
        * match(value)
        *  .with(P.object.empty(), () => 'empty object')
        */
-      empty<input>(): ObjectChainable<
+      empty<input>(): Chainable<
         ObjectP<input, Record<string, never>>,
         omitted | 'empty'
       >;

--- a/tests/object.test.ts
+++ b/tests/object.test.ts
@@ -20,6 +20,66 @@ describe('Object', () => {
     expect(res).toEqual('not found');
   });
 
+  it('when input is a Function, it should not match as an exact object', () => {
+    const fn = () => () => {};
+
+    const res = match(fn())
+      .with(P.object, (obj) => {
+        type t = Expect<Equal<typeof obj, () => void>>;
+        return 'not found';
+      })
+      .otherwise(() => 'not found');
+    expect(res).toEqual('not found');
+  })
+
+  it('when input is a Number (a primitive value), it should not be matched as an exact object', () => {
+    const fn = () => 1_000_000;
+
+    const res = match(fn())
+      .with(P.object, (obj) => {
+        type t = Expect<Equal<typeof obj, number>>;
+        return 'not found';
+      })
+      .otherwise(() => 'not found');
+    expect(res).toEqual('not found');
+  })
+
+  it('when input is a String (a primitive value), it should not be matched as an exact object', () => {
+    const fn = () => 'hello';
+
+    const res = match(fn())
+      .with(P.object, (obj) => {
+        type t = Expect<Equal<typeof obj, string>>;
+        return 'not found';
+      })
+      .otherwise(() => 'not found');
+    expect(res).toEqual('not found');
+  })
+
+  it('when input is a Boolean (a primitive value), it should not be matched as an exact object', () => {
+    const fn = () => true;
+
+    const res = match(fn())
+      .with(P.object, (obj) => {
+        type t = Expect<Equal<typeof obj, boolean>>;
+        return 'not found';
+      })
+      .otherwise(() => 'not found');
+    expect(res).toEqual('not found');
+  })
+
+  it('when input is Null, it should not be matched as an exact object', () => {
+    const fn = () => null;
+
+    const res = match(fn())
+      .with(P.object, (obj) => {
+        type t = Expect<Equal<typeof obj, null>>;
+        return 'not found';
+      })
+      .otherwise(() => 'not found');
+    expect(res).toEqual('not found');
+  })
+
   it('should match object with nested objects', () => {
     const res = match({ x: { y: 1 } })
       .with({ x: { y: 1 } }, (obj) => {
@@ -45,6 +105,7 @@ describe('Object', () => {
         return 'no';
       })
       .exhaustive();
+
     expect(res).toEqual('yes');
   });
 
@@ -64,7 +125,7 @@ describe('Object', () => {
     expect(res).toEqual('yes');
   });
 
-  it('should match object with optional properties', () => {
+  it('should properly match an object against the P.object pattern, even with optional properties', () => {
     const res = match({ x: 1 })
       .with(P.object.empty(), (obj) => {
         type t = Expect<Equal<typeof obj, { readonly x: 1; }>>;

--- a/tests/object.test.ts
+++ b/tests/object.test.ts
@@ -1,0 +1,80 @@
+import { Expect, Equal } from '../src/types/helpers';
+import { P, match } from '../src';
+
+describe('Object', () => {
+  it('should match exact object', () => {
+    const fn = () => 'hello';
+
+    const res = match({ str: fn() })
+      .with({ str: 'world' }, (obj) => {
+        type t = Expect<Equal<typeof obj, { str: 'world' }>>;
+        return obj.str;
+      })
+      .with(P.object, (obj) => {
+        type t = Expect<Equal<typeof obj, {
+          readonly str: string;
+        }>>;
+        return 'not found';
+      })
+      .exhaustive();
+    expect(res).toEqual('not found');
+  });
+
+  it('should match object with nested objects', () => {
+    const res = match({ x: { y: 1 } })
+      .with({ x: { y: 1 } }, (obj) => {
+        type t = Expect<Equal<typeof obj, { readonly x: { readonly y: 1 } }>>;
+        return 'yes';
+      })
+      .with(P.object, (obj) => {
+        type t = Expect<Equal<typeof obj, never>>;
+        return 'no';
+      })
+      .exhaustive();
+    expect(res).toEqual('yes');
+  });
+
+  it('should match object with nested objects and arrays', () => {
+    const res = match({ x: { y: [1] } })
+      .with({ x: { y: [1] } }, (obj) => {
+        type t = Expect<Equal<typeof obj, { x: { y: [1] } }>>;
+        return 'yes';
+      })
+      .with(P.object, (obj) => {
+        type t = Expect<Equal<typeof obj, { readonly x: { readonly y: readonly [1]}}>>;
+        return 'no';
+      })
+      .exhaustive();
+    expect(res).toEqual('yes');
+  });
+
+  it('should match empty object', () => {
+    const res = match({})
+      .with(P.object.empty(), (obj) => {
+        type t = Expect<Equal<typeof obj, {}>>;
+
+        return 'yes';
+      })
+      .with(P.object, (obj) => {
+        type t = Expect<Equal<typeof obj, never>>;
+
+        return 'no';
+      })
+      .exhaustive();
+    expect(res).toEqual('yes');
+  });
+
+  it('should match object with optional properties', () => {
+    const res = match({ x: 1 })
+      .with(P.object.empty(), (obj) => {
+        type t = Expect<Equal<typeof obj, { readonly x: 1; }>>;
+        return 'no';
+      })
+      .with(P.object, (obj) => {
+        type t = Expect<Equal<typeof obj, never>>;
+        return 'yes';
+      })
+      .exhaustive();
+    expect(res).toEqual('yes');
+  });
+});

--- a/tests/object.test.ts
+++ b/tests/object.test.ts
@@ -117,7 +117,7 @@ describe('Object', () => {
         return 'yes';
       })
       .with(P.object, (obj) => {
-        type t = Expect<Equal<typeof obj, never>>;
+        type t = Expect<Equal<typeof obj, {}>>;
 
         return 'no';
       })
@@ -132,7 +132,9 @@ describe('Object', () => {
         return 'no';
       })
       .with(P.object, (obj) => {
-        type t = Expect<Equal<typeof obj, never>>;
+        type t = Expect<Equal<typeof obj, {
+          readonly x: 1;
+      }>>;
         return 'yes';
       })
       .exhaustive();


### PR DESCRIPTION
## Add P.object and P.object.empty

Add a pattern to match all 'Object' and 'Empty Object'.

### `P.object`
```ts
const fn = (input: object) =>
  match(input)
    .with(P.object, () => 'Object!')
    .otherwise(() => '???');

console.log(fn({ str: 'hello' })); // Object!
```

### `P.object.empty`
```ts
const fn = (input: string) =>
  match(input)
    .with(P.object.empty(), () => 'Empty!')
    .otherwise(() => 'Full!');

console.log(fn({})); // Empty!
```

Issue number: #230 