### PR TITLE
fix: exhaustive checking with nested P.nonNullable patterns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-pattern",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-pattern",
-      "version": "5.1.1",
+      "version": "5.1.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": " The exhaustive Pattern Matching library for TypeScript.",
   "type": "module",
   "source": "src/index.ts",

--- a/src/types/IsMatching.ts
+++ b/src/types/IsMatching.ts
@@ -65,6 +65,11 @@ export type IsMatching<a, b> = true extends IsUnion<a> | IsUnion<b>
   // match everything.
   unknown extends b
   ? true
+  : // Special case for `{}`, because this is the type
+  // of the inverted `P.nonNullable` wildcard pattern,
+  // which should match all objects.
+  {} extends b
+  ? true
   : b extends Primitives
   ? // if the pattern is a primitive, we want to check if there is
     // an overlap between a and b!

--- a/tests/type-is-matching.test.ts
+++ b/tests/type-is-matching.test.ts
@@ -201,7 +201,9 @@ describe('IsMatching', () => {
             false
           >
         >,
-        Expect<Equal<IsMatching<{ type: 'a' }, {}>, false>>,
+        // the empty object matches everything except null | undefined
+        // just like the `{}` type.
+        Expect<Equal<IsMatching<{ type: 'a' }, {}>, true>>,
         Expect<Equal<IsMatching<{}, { type: 'a' }>, false>>
       ];
     });

--- a/tests/wildcards.test.ts
+++ b/tests/wildcards.test.ts
@@ -113,6 +113,28 @@ describe('wildcards', () => {
         'matched'
       );
     });
+
+    it('combined with exhaustive, it should consider all values except null and undefined to be handled', () => {
+      const fn1 = (input: string | number | null | undefined) =>
+        match(input)
+          .with(P.nonNullable, (x) => {
+            type t = Expect<Equal<typeof x, string | number>>;
+          })
+          .with(P.nullish, () => {})
+          // should type-check
+          .exhaustive();
+
+      const fn2 = (input: { nested: string | number | null | undefined }) =>
+        match(input)
+          .with({ nested: P.nonNullable }, (x) => {
+            type t = Expect<Equal<typeof x, { nested: string | number }>>;
+          })
+          .with({ nested: P.nullish }, (x) => {
+            type t = Expect<Equal<typeof x, { nested: null | undefined }>>;
+          })
+          // should type-check
+          .exhaustive();
+    });
   });
 
   it('should match String, Number and Boolean wildcards', () => {
@@ -202,7 +224,7 @@ describe('wildcards', () => {
         expect(
           match(value)
             .with(P._, () => 'yes')
-            .run()
+            .exhaustive()
         ).toEqual('yes');
       });
     });


### PR DESCRIPTION
Fixes issue https://github.com/gvergnaud/ts-pattern/issues/247

The when combining `P.nonNullable` and `P.nullish`, you should get an exhaustive pattern matching expression, but the following case was incorrectly considered non-exhaustive:

```ts 
declare const input: {
  nested: string | number | null | undefined;
};

const res = match(input)
  .with({ nested: P.nonNullable }, (x) => {/* ... */})
  .with({ nested: P.nullish }, (x) => {/* ... */})
  // should type-check
  .exhaustive();
```

This is fixed now.
