### PR TITLE
feat(exhaustive): Add support for passing a fallback function

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,12 +544,36 @@ match(...)
   .exhaustive()
 ```
 
-Runs the pattern-matching expression and returns its result. It also enables exhaustiveness checking, making sure at compile time that we have handled all possible cases.
+Runs the pattern-matching expression and returns its result. It also enables exhaustiveness checking, making sure that we have handled all possible cases **at compile time**.
+
+By default, `.exhaustive()` will throw an error if the input value wasn't handled by any `.with(...)` clause. This should only happen if your types are incorrect.
+
+It is possible to pass your own handler function as a parameter to decide what should happen if an unexpected value has been received. You can for example throw your own custom error:
+
+```ts
+match(...)
+  .with(...)
+  .exhaustive((unexpected: unknown) => {
+    throw MyCustomError(unexpected);
+  })
+```
+
+Or log an error and return a default value:
+
+```ts
+match<string, number>(...)
+  .with(P.string, (str) => str.length)
+  .exhaustive((notAString: unknown) => {
+    console.log(`received an unexpected value: ${notAString}`);
+    return 0;
+  })
+```
 
 #### Signature
 
 ```ts
 function exhaustive(): TOutput;
+function exhaustive(handler: (unexpectedValue: unknown) => TOutput): TOutput;
 ```
 
 #### Example

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-pattern",
-  "version": "5.6.2",
+  "version": "5.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-pattern",
-      "version": "5.6.2",
+      "version": "5.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "5.6.2",
+  "version": "5.7.0",
   "description": " The exhaustive Pattern Matching library for TypeScript.",
   "type": "module",
   "source": "src/index.ts",

--- a/src/match.ts
+++ b/src/match.ts
@@ -112,10 +112,9 @@ class MatchExpression<input, output> {
     return handler(this.input);
   }
 
-  exhaustive(): output {
+  exhaustive(catcher = defaultCatcher): output {
     if (this.state.matched) return this.state.value;
-
-    throw new NonExhaustiveError(this.input);
+    return catcher(this.input);
   }
 
   run(): output {
@@ -125,4 +124,8 @@ class MatchExpression<input, output> {
   returnType() {
     return this;
   }
+}
+
+function defaultCatcher(input: unknown): never {
+  throw new NonExhaustiveError(input);
 }

--- a/src/match.ts
+++ b/src/match.ts
@@ -112,9 +112,9 @@ class MatchExpression<input, output> {
     return handler(this.input);
   }
 
-  exhaustive(catcher = defaultCatcher): output {
+  exhaustive(unexpectedValueHandler = defaultCatcher): output {
     if (this.state.matched) return this.state.value;
-    return catcher(this.input);
+    return unexpectedValueHandler(this.input);
   }
 
   run(): output {

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -190,7 +190,7 @@ export type Match<
    *
    * [Read the documentation for `.exhaustive()` on GitHub](https://github.com/gvergnaud/ts-pattern#exhaustive)
    *
-   * */
+   */
   exhaustive: DeepExcludeAll<i, handledCases> extends infer remainingCases
     ? [remainingCases] extends [never]
       ? Exhaustive<o, inferredOutput>
@@ -201,14 +201,14 @@ export type Match<
    * `.run()` return the resulting value.
    *
    * ⚠️ calling this function is unsafe, and may throw if no pattern matches your input.
-   * */
+   */
   run(): PickReturnValue<o, inferredOutput>;
 
   /**
    * `.returnType<T>()` Lets you specify the return type for all of your branches.
    *
    * [Read the documentation for `.returnType()` on GitHub](https://github.com/gvergnaud/ts-pattern#returnType)
-   * */
+   */
   returnType: [inferredOutput] extends [never]
     ? <output>() => Match<i, output, handledCases>
     : TSPatternError<'calling `.returnType<T>()` is only allowed directly after `match(...)`.'>;
@@ -257,21 +257,20 @@ type Exhaustive<output, inferredOutput> = {
    *
    * [Read the documentation for `.exhaustive()` on GitHub](https://github.com/gvergnaud/ts-pattern#exhaustive)
    *
-   * */
+   */
   (): PickReturnValue<output, inferredOutput>;
   /**
-   * `.exhaustive(fallback)` checks that all cases are handled, and returns the result value.
+   * `.exhaustive(fallback)` checks that all cases are handled and returns the result value.
+   *
+   * The fallback function will be called if your input value doesn't match any pattern.
+   * This can only happen if the value you passed to `match` has an incorrect type.
    *
    * If you get a `NonExhaustiveError`, it means that you aren't handling
    * all cases. You should probably add another `.with(...)` clause
-   * to match the missing case and prevent runtime errors.
-   *
-   * The fallback function will be called if your input value doesn't match any pattern. This can only
-   * happen if the type of your input is incorrect.
+   * to match the missing case.
    *
    * [Read the documentation for `.exhaustive()` on GitHub](https://github.com/gvergnaud/ts-pattern#exhaustive)
-   *
-   * */
+   */
   <otherOutput>(
     handler: (unexpectedValue: unknown) => PickReturnValue<output, otherOutput>
   ): PickReturnValue<output, Union<inferredOutput, otherOutput>>;

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -248,7 +248,30 @@ type MakeTuples<ps extends readonly any[], value> = {
  * By default, TS-Pattern will throw an error if a runtime value isn't handled.
  */
 type Exhaustive<output, inferredOutput> = {
+  /**
+   * `.exhaustive()` checks that all cases are handled, and returns the result value.
+   *
+   * If you get a `NonExhaustiveError`, it means that you aren't handling
+   * all cases. You should probably add another `.with(...)` clause
+   * to match the missing case and prevent runtime errors.
+   *
+   * [Read the documentation for `.exhaustive()` on GitHub](https://github.com/gvergnaud/ts-pattern#exhaustive)
+   *
+   * */
   (): PickReturnValue<output, inferredOutput>;
+  /**
+   * `.exhaustive(fallback)` checks that all cases are handled, and returns the result value.
+   *
+   * If you get a `NonExhaustiveError`, it means that you aren't handling
+   * all cases. You should probably add another `.with(...)` clause
+   * to match the missing case and prevent runtime errors.
+   *
+   * The fallback function will be called if your input value doesn't match any pattern. This can only
+   * happen if the type of your input is incorrect.
+   *
+   * [Read the documentation for `.exhaustive()` on GitHub](https://github.com/gvergnaud/ts-pattern#exhaustive)
+   *
+   * */
   <otherOutput>(
     handler: (unexpectedValue: unknown) => PickReturnValue<output, otherOutput>
   ): PickReturnValue<output, Union<inferredOutput, otherOutput>>;

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -250,6 +250,6 @@ type MakeTuples<ps extends readonly any[], value> = {
 type Exhaustive<output, inferredOutput> = {
   (): PickReturnValue<output, inferredOutput>;
   <otherOutput>(
-    handler: (unmatchedValue: unknown) => PickReturnValue<output, otherOutput>
+    handler: (unexpectedValue: unknown) => PickReturnValue<output, otherOutput>
   ): PickReturnValue<output, Union<inferredOutput, otherOutput>>;
 };

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -193,7 +193,7 @@ export type Match<
    * */
   exhaustive: DeepExcludeAll<i, handledCases> extends infer remainingCases
     ? [remainingCases] extends [never]
-      ? () => PickReturnValue<o, inferredOutput>
+      ? Exhaustive<o, inferredOutput>
       : NonExhaustiveError<remainingCases>
     : never;
 
@@ -239,4 +239,15 @@ type DeepExcludeAll<a, tupleList extends any[]> = [a] extends [never]
 
 type MakeTuples<ps extends readonly any[], value> = {
   -readonly [index in keyof ps]: InvertPatternForExclude<ps[index], value>;
+};
+
+/**
+ * The type of an overloaded function for `.exhaustive`,
+ * permitting calling it with out without a catchall function.
+ */
+type Exhaustive<output, inferredOutput> = {
+  (): PickReturnValue<output, inferredOutput>;
+  <otherOutput>(
+    handler: (unmatchedValue: unknown) => PickReturnValue<output, otherOutput>
+  ): PickReturnValue<output, Union<inferredOutput, otherOutput>>;
 };

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -243,7 +243,9 @@ type MakeTuples<ps extends readonly any[], value> = {
 
 /**
  * The type of an overloaded function for `.exhaustive`,
- * permitting calling it with out without a catchall function.
+ * permitting calling it with or without a catch-all handler function.
+ *
+ * By default, TS-Pattern will throw an error if a runtime value isn't handled.
  */
 type Exhaustive<output, inferredOutput> = {
   (): PickReturnValue<output, inferredOutput>;

--- a/tests/exhaustive-fallback.test.ts
+++ b/tests/exhaustive-fallback.test.ts
@@ -1,0 +1,48 @@
+import { match, P } from '../src';
+import { Equal, Expect } from '../src/types/helpers';
+
+describe('Exhaustive fallback function', () => {
+  it("should be called if the runtime value isn't expected", () => {
+    const input: 'a' | 'b' = 'c' as any;
+    const result = match(input)
+      .with('a', (x) => x)
+      .with('b', (x) => x)
+      .exhaustive((v) => ({ unexpectedValue: v }));
+
+    // check return type
+    type t = Expect<
+      Equal<typeof result, { unexpectedValue: unknown } | 'a' | 'b'>
+    >;
+
+    expect(result).toStrictEqual({ unexpectedValue: 'c' });
+  });
+
+  it('should throw otherwise', () => {
+    expect(() => {
+      const input: 'a' | 'b' = 'c' as any;
+      return match(input)
+        .with('a', (x) => x)
+        .with('b', (x) => x)
+        .exhaustive();
+    }).toThrow();
+  });
+
+  it('should return a value assignable to the explicit output type', () => {
+    const input: 'a' | 'b' = 'c' as any;
+    const res = match<typeof input, 'a' | 'b'>(input)
+      .with('a', (x) => x)
+      .with('b', (x) => x)
+      // @ts-expect-error 'c' isn't assignable to a|b
+      .exhaustive(() => 'c');
+  });
+
+  it('should return a value assignable .returnType<T>()', () => {
+    const input: 'a' | 'b' = 'c' as any;
+    const res = match(input)
+      .returnType<'a' | 'b'>()
+      .with('a', (x) => x)
+      .with('b', (x) => x)
+      // @ts-expect-error 'c' isn't assignable to a|b
+      .exhaustive(() => 'c');
+  });
+});

--- a/tests/exhaustive-fallback.test.ts
+++ b/tests/exhaustive-fallback.test.ts
@@ -9,7 +9,6 @@ describe('Exhaustive fallback function', () => {
       .with('b', (x) => x)
       .exhaustive((v) => ({ unexpectedValue: v }));
 
-    // check return type
     type t = Expect<
       Equal<typeof result, { unexpectedValue: unknown } | 'a' | 'b'>
     >;
@@ -33,7 +32,10 @@ describe('Exhaustive fallback function', () => {
       .with('a', (x) => x)
       .with('b', (x) => x)
       // @ts-expect-error 'c' isn't assignable to a|b
-      .exhaustive(() => 'c');
+      .exhaustive(() => {
+        // Note: ideally the error message should be here.
+        return 'c';
+      });
   });
 
   it('should return a value assignable .returnType<T>()', () => {


### PR DESCRIPTION
Solves #144 #218 and replaces #38  #219

## Docs

By default, `.exhaustive()` will throw an error if the input value wasn't handled by any `.with(...)` clause. This should only happen if your types are incorrect.

It is possible to pass your own handler function as a parameter to decide what should happen if an unexpected value has been received. You can for example throw your own custom error:

```ts
match(...)
  .with(...)
  .exhaustive((unexpected: unknown) => {
    throw MyCustomError(unexpected);
  })
```

Or log an error and return a default value:

```ts
match<string, number>(...)
  .with(P.string, (str) => str.length)
  .exhaustive((notAString: unknown) => {
    console.log(`received an unexpected value: ${notAString}`);
    return 0;
  })
```
