### PR TITLE
docs: fix typo in `P.when` patterns code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1071,7 +1071,7 @@ import { match, P } from 'ts-pattern';
 
 type Input = { score: number };
 
-const output = match({ score: 10 })
+const output = match<Input>({ score: 10 })
   .with(
     {
       score: P.when((score): score is 5 => score === 5),


### PR DESCRIPTION
Hey, nice project! As I was reading the `README.md` file, I came across a typo in the code example for `P.when` patterns, which causes TypeScript issues. I would be happy to make any further adjustments as needed. Please feel free to close the PR if you think this change is unnecessary. 