### PR TITLE
feat: .narrow() method & typechecking perf improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Type-Level TypeScript takes you on a deep dive into the most advanced features o
   - [`.returnType`](#returntype)
   - [`.exhaustive`](#exhaustive)
   - [`.otherwise`](#otherwise)
+  - [`.narrow`](#narrow)
   - [`isMatching`](#ismatching)
   - [Patterns](#patterns)
     - [Literals](#literals)
@@ -638,6 +639,43 @@ returns the result of the pattern-matching expression, or **throws** if no patte
 
 ```ts
 function run(): TOutput;
+```
+
+### `.narrow`
+
+```ts
+match(...)
+  .with(...)
+  .narrow()
+  .with(...)
+```
+
+The `.narrow()` method deeply narrows the input type to exclude all values that have previously been handled. This is useful when you want to exclude cases from union types or nullable properties that are deeply nested.
+
+Note that handled case of top-level union types are excluded by default, without calling `.narrow()`.
+
+#### Signature
+
+```ts
+function narrow(): Match<Narrowed<TInput>, TOutput>;
+```
+
+#### Example
+
+```ts
+type Input = { color: 'red' | 'blue'; size: 'small' | 'large' };
+
+declare const input: Input;
+
+const result = match(input)
+  .with({ color: 'red', size: 'small' }, (red) => `Red: ${red.size}`)
+  .with({ color: 'blue', size: 'large' }, (red) => `Red: ${red.size}`)
+  .narrow() // 👈
+  .otherwise((narrowedInput) => {
+    // narrowedInput:
+    // | { color: 'red'; size: 'large' }
+    // | { color: 'blue'; size: 'small' }
+  });
 ```
 
 ### `isMatching`

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@gabriel/ts-pattern",
-  "version": "5.7.1",
+  "version": "5.8.0",
   "exports": {
     ".": "./src/index.ts",
     "./types": "./src/index.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-pattern",
-  "version": "5.7.1",
+  "version": "5.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-pattern",
-      "version": "5.7.1",
+      "version": "5.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dev": "microbundle watch",
     "prepublishOnly": "npm run test && npm run build",
     "publish:jsr": "npm run prepublishOnly && npx jsr publish",
+    "release": "npm run prepublishOnly && npm publish && npx jsr publish",
     "test": "jest",
     "clear-test": "jest --clearCache",
     "fmt": "prettier ./src/** ./tests/** -w",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "5.7.1",
+  "version": "5.8.0",
   "description": " The exhaustive Pattern Matching library for TypeScript.",
   "type": "module",
   "source": "src/index.ts",

--- a/src/match.ts
+++ b/src/match.ts
@@ -124,6 +124,10 @@ class MatchExpression<input, output> {
   returnType() {
     return this;
   }
+
+  narrow() {
+    return this;
+  }
 }
 
 function defaultCatcher(input: unknown): never {

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -212,6 +212,17 @@ export type Match<
   returnType: [inferredOutput] extends [never]
     ? <output>() => Match<i, output, handledCases>
     : TSPatternError<'calling `.returnType<T>()` is only allowed directly after `match(...)`.'>;
+
+  /**
+   * `.narrow()` narrows the input type to exclude all cases that have previously been handled.
+   *
+   * `.narrow()` is only useful if you want to excluded cases from union types or nullable
+   * properties that are deeply nested. Handled cases from top level union types are excluded
+   * by default.
+   *
+   * [Read the documentation for `.narrow() on GitHub](https://github.com/gvergnaud/ts-pattern#narrow)
+   */
+  narrow(): Match<DeepExcludeAll<i, handledCases>, o, [], inferredOutput>;
 };
 
 /**

--- a/tests/narrow.test.ts
+++ b/tests/narrow.test.ts
@@ -1,4 +1,4 @@
-import { P } from '../src';
+import { P, match } from '../src';
 import { Equal, Expect } from '../src/types/helpers';
 
 describe('P.narrow', () => {
@@ -10,4 +10,27 @@ describe('P.narrow', () => {
     //     ^?
     type test = Expect<Equal<Narrowed, ['a', 'a' | 'b']>>;
   });
+});
+
+describe('.narrow() method', () => {
+  it('should excluded values from deeply nested union types.', () => {
+    const fn = (input: { prop?: string }) =>
+      match(input)
+        .with({ prop: P.nullish.optional() }, () => false)
+        .narrow()
+        .otherwise(({ prop }) => {
+          type test = Expect<Equal<typeof prop, string>>;
+          return true;
+        });
+  });
+
+  const fn2 = (input: { prop?: 1 | 2 | 3 }) =>
+    match(input)
+      .with({ prop: P.nullish.optional() }, () => false)
+      .with({ prop: 2 }, () => false)
+      .narrow()
+      .otherwise(({ prop }) => {
+        type test = Expect<Equal<typeof prop, 1 | 3>>;
+        return true;
+      });
 });


### PR DESCRIPTION
Add a .narrow() method to force a deep type narrowing after a `.with` clause. See https://x.com/GabrielVergnaud/status/1795208610965782626

Example:

```ts
const fn = (input: { prop?: string }) =>
      match(input)
        .with({ prop: P.nullish.optional() }, () => false)
        .narrow()
        .otherwise(({ prop }) => {
          //          ^? string
          return true;
        });