### PR TITLE
feat: throw custom `ExhaustiveError` when no matched pattern

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,15 @@
+/**
+ * Error when the given input value does not match any included pattern
+ * and .exhaustive() was specified
+ */
+export class ExhaustiveError extends Error {
+  constructor(public input: unknown) {
+    let displayedValue;
+    try {
+      displayedValue = JSON.stringify(input);
+    } catch (e) {
+      displayedValue = input;
+    }
+    super(`Pattern matching error: no pattern matches value ${displayedValue}`);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ import * as Pattern from './patterns';
 export { match } from './match';
 export { isMatching } from './is-matching';
 export { Pattern, Pattern as P };
+export { ExhaustiveError } from './errors';

--- a/src/match.ts
+++ b/src/match.ts
@@ -2,6 +2,7 @@ import { Pattern } from './types/Pattern';
 import { Match } from './types/Match';
 import * as symbols from './internals/symbols';
 import { matchPattern } from './internals/helpers';
+import { ExhaustiveError } from './errors';
 
 type MatchState<output> =
   | { matched: true; value: output }
@@ -114,16 +115,7 @@ class MatchExpression<input, output> {
   exhaustive(): output {
     if (this.state.matched) return this.state.value;
 
-    let displayedValue;
-    try {
-      displayedValue = JSON.stringify(this.input);
-    } catch (e) {
-      displayedValue = this.input;
-    }
-
-    throw new Error(
-      `Pattern matching error: no pattern matches value ${displayedValue}`
-    );
+    throw new ExhaustiveError(this.input);
   }
 
   run(): output {


### PR DESCRIPTION
This adds/exports a custom `ExhaustiveError` which will be thrown at runtime when a `match` input doesn't match any pattern and `.exhaustive()` has been specified. This gives better error handling capabilities, for example when trying to distinguish between an unmatched pattern error and an error thrown within a matched pattern's callback.

Resolves #269 

