### PR TITLE
Symbols as keys

### DIFF
--- a/src/internals/helpers.ts
+++ b/src/internals/helpers.ts
@@ -103,7 +103,10 @@ export const matchPattern = (
         : false;
     }
 
-    return Object.keys(pattern).every((k: string): boolean => {
+    return [
+      ...Object.getOwnPropertySymbols(pattern),
+      ...Object.keys(pattern),
+    ].every((k: string | symbol): boolean => {
       // @ts-ignore
       const subPattern = pattern[k];
 

--- a/tests/is-matching.test.ts
+++ b/tests/is-matching.test.ts
@@ -77,27 +77,4 @@ describe('isMatching', () => {
       throw new Error('Expected food to match the pizza pattern!');
     }
   });
-  it('should work with symbols', () => {
-    const symbolA = Symbol('symbol-a');
-    const symbolB = Symbol('symbol-b');
-    const obj: { [symbolA]: { [symbolB]: 'foo' | 'bar' } } = {
-      [symbolA]: { [symbolB]: 'foo' },
-    };
-    if (isMatching({ [symbolA]: { [symbolB]: 'foo' } }, obj)) {
-      type t = Expect<Equal<typeof obj, { [symbolA]: { [symbolB]: 'foo' } }>>;
-    } else {
-      throw new Error('Expected obj to match the foo pattern!');
-    }
-    if (isMatching({ [symbolA]: { [symbolB]: 'bar' } }, obj)) {
-      type t = Expect<
-        Equal<
-          typeof obj,
-          { [symbolA]: { [symbolB]: 'foo' } } & {
-            [symbolA]: { [symbolB]: 'bar' };
-          }
-        >
-      >;
-      throw new Error('Expected obj to not match the bar pattern!');
-    }
-  });
 });

--- a/tests/is-matching.test.ts
+++ b/tests/is-matching.test.ts
@@ -77,4 +77,27 @@ describe('isMatching', () => {
       throw new Error('Expected food to match the pizza pattern!');
     }
   });
+  it('should work with symbols', () => {
+    const symbolA = Symbol('symbol-a');
+    const symbolB = Symbol('symbol-b');
+    const obj: { [symbolA]: { [symbolB]: 'foo' | 'bar' } } = {
+      [symbolA]: { [symbolB]: 'foo' },
+    };
+    if (isMatching({ [symbolA]: { [symbolB]: 'foo' } }, obj)) {
+      type t = Expect<Equal<typeof obj, { [symbolA]: { [symbolB]: 'foo' } }>>;
+    } else {
+      throw new Error('Expected obj to match the foo pattern!');
+    }
+    if (isMatching({ [symbolA]: { [symbolB]: 'bar' } }, obj)) {
+      type t = Expect<
+        Equal<
+          typeof obj,
+          { [symbolA]: { [symbolB]: 'foo' } } & {
+            [symbolA]: { [symbolB]: 'bar' };
+          }
+        >
+      >;
+      throw new Error('Expected obj to not match the bar pattern!');
+    }
+  });
 });

--- a/tests/objects.test.ts
+++ b/tests/objects.test.ts
@@ -1,0 +1,28 @@
+import { isMatching, P } from '../src';
+import { Equal, Expect } from '../src/types/helpers';
+
+describe('Objects', () => {
+  it('should work with symbols', () => {
+    const symbolA = Symbol('symbol-a');
+    const symbolB = Symbol('symbol-b');
+    const obj: { [symbolA]: { [symbolB]: 'foo' | 'bar' } } = {
+      [symbolA]: { [symbolB]: 'foo' },
+    };
+    if (isMatching({ [symbolA]: { [symbolB]: 'foo' } }, obj)) {
+      type t = Expect<Equal<typeof obj, { [symbolA]: { [symbolB]: 'foo' } }>>;
+    } else {
+      throw new Error('Expected obj to match the foo pattern!');
+    }
+    if (isMatching({ [symbolA]: { [symbolB]: 'bar' } }, obj)) {
+      type t = Expect<
+        Equal<
+          typeof obj,
+          { [symbolA]: { [symbolB]: 'foo' } } & {
+            [symbolA]: { [symbolB]: 'bar' };
+          }
+        >
+      >;
+      throw new Error('Expected obj to not match the bar pattern!');
+    }
+  });
+});


### PR DESCRIPTION
I noticed that `isMatching` wasn't working with symbols:

<img width="689" alt="image" src="https://github.com/user-attachments/assets/46fc45e2-b2fa-4032-b348-8505f653cc75">

But the exact same code works with strings:

<img width="708" alt="image" src="https://github.com/user-attachments/assets/b4a18465-9e30-42ce-969b-6148257e7844">

So I updated the `matchPattern` function to also iterate through symbols in addition to keys (`Object.keys()` skips symbols, but we can use `Object.getOwnPropertySymbols()` for those)

I also added a test that is failing without my changes, but passes after:

Before | After
-|-
<img width="674" alt="image" src="https://github.com/user-attachments/assets/4c088d8b-3e75-49cf-a02b-a6aef477d294"> | <img width="398" alt="image" src="https://github.com/user-attachments/assets/08468e26-b1c7-480e-a4d6-c357e5ba2b49">

