### PR TITLE
Fixes type `InvertPatternForExcludeInternal` to work with readonly array

### DIFF
--- a/src/types/InvertPattern.ts
+++ b/src/types/InvertPattern.ts
@@ -318,9 +318,10 @@ type InvertPatternForExcludeInternal<p, i, empty = never> =
     ? {
         select: InvertPatternForExcludeInternal<subpattern, i, empty>;
         array: i extends readonly (infer ii)[]
-          ? i extends any[]
-            ? InvertPatternForExcludeInternal<subpattern, ii, empty>[]
-            : readonly InvertPatternForExcludeInternal<subpattern, ii, empty>[]
+          ? MaybeAddReadonly<
+              InvertPatternForExcludeInternal<subpattern, ii, empty>[],
+              IsReadonlyArray<i>
+            >
           : empty;
         map: subpattern extends [infer pk, infer pv]
           ? i extends Map<infer ik, infer iv>

--- a/src/types/InvertPattern.ts
+++ b/src/types/InvertPattern.ts
@@ -318,7 +318,9 @@ type InvertPatternForExcludeInternal<p, i, empty = never> =
     ? {
         select: InvertPatternForExcludeInternal<subpattern, i, empty>;
         array: i extends readonly (infer ii)[]
-          ? InvertPatternForExcludeInternal<subpattern, ii, empty>[]
+          ? i extends any[]
+            ? InvertPatternForExcludeInternal<subpattern, ii, empty>[]
+            : readonly InvertPatternForExcludeInternal<subpattern, ii, empty>[]
           : empty;
         map: subpattern extends [infer pk, infer pv]
           ? i extends Map<infer ik, infer iv>

--- a/tests/exhaustive-match.test.ts
+++ b/tests/exhaustive-match.test.ts
@@ -985,8 +985,8 @@ describe('exhaustive()', () => {
     const input = ['a', 'b', 'c'] as Input;
 
     const output = match(input)
-      .with(P.array(P.string), (value) => 2)
-      .with(P.string, (value) => 1)
+      .with(P.array(P.string), (value) => 1)
+      .with(P.string, (value) => 2)
       .with(P.instanceOf(Date), (value) => 3)
       .exhaustive();
   });

--- a/tests/exhaustive-match.test.ts
+++ b/tests/exhaustive-match.test.ts
@@ -980,7 +980,7 @@ describe('exhaustive()', () => {
     });
   });
 
-  it('issue #271: P.array should support readonly arrays as its input', () => {
+  it('issue #271: P.array should exhaustively match readonly arrays', () => {
     type Input = string | Date | readonly string[];
     const input = ['a', 'b', 'c'] as Input;
 

--- a/tests/exhaustive-match.test.ts
+++ b/tests/exhaustive-match.test.ts
@@ -979,4 +979,15 @@ describe('exhaustive()', () => {
       expect(withoutTypo({ sex: 'b', age: 'c' })).toBe(1);
     });
   });
+
+  it('issue #271: P.array should support readonly arrays as its input', () => {
+    type Input = string | Date | readonly string[];
+    const input = ['a', 'b', 'c'] as Input;
+
+    const output = match(input)
+      .with(P.array(P.string), (value) => 2)
+      .with(P.string, (value) => 1)
+      .with(P.instanceOf(Date), (value) => 3)
+      .exhaustive();
+  });
 });

--- a/tests/lists.test.ts
+++ b/tests/lists.test.ts
@@ -59,6 +59,17 @@ describe('List ([a])', () => {
       .otherwise(() => 'something else');
   });
 
+  it('issue #271: P.array should support readonly arrays as its input', () => {
+    type Input = string | Date | readonly string[];
+    const input = ['a', 'b', 'c'] as Input;
+
+    const output = match(input)
+      .with(P.array(P.string), (value) => 2)
+      .with(P.string, (value) => 1)
+      .with(P.instanceOf(Date), (value) => 3)
+      .exhaustive();
+  });
+
   it('type narrowing should work on nested arrays', () => {
     const fn = (input: { queries?: { q?: string[]; a: number }[] }) =>
       match(input).with(

--- a/tests/lists.test.ts
+++ b/tests/lists.test.ts
@@ -59,17 +59,6 @@ describe('List ([a])', () => {
       .otherwise(() => 'something else');
   });
 
-  it('issue #271: P.array should support readonly arrays as its input', () => {
-    type Input = string | Date | readonly string[];
-    const input = ['a', 'b', 'c'] as Input;
-
-    const output = match(input)
-      .with(P.array(P.string), (value) => 2)
-      .with(P.string, (value) => 1)
-      .with(P.instanceOf(Date), (value) => 3)
-      .exhaustive();
-  });
-
   it('type narrowing should work on nested arrays', () => {
     const fn = (input: { queries?: { q?: string[]; a: number }[] }) =>
       match(input).with(


### PR DESCRIPTION
This PR resolves the issue https://github.com/gvergnaud/ts-pattern/issues/271

Fixed the issue by modifying `InvertPatternForExcludeInternal` to consider `readonly` .