### PR TITLE
perf: improve type checking performance of BuildMany

### DIFF
--- a/src/types/DistributeUnions.ts
+++ b/src/types/DistributeUnions.ts
@@ -146,15 +146,7 @@ export type FindUnions<
     ? IsStrictArray<Extract<a, readonly any[]>> extends false
       ? []
       : [
-          MaybeAddReadonly<
-            | (a extends readonly [any, ...any] | readonly [...any, any]
-                ? never
-                : [])
-            | (p extends readonly [...any, any]
-                ? [...Extract<a, readonly any[]>, ValueOf<a>]
-                : [ValueOf<a>, ...Extract<a, readonly any[]>]),
-            IsReadonlyArray<a>
-          > extends infer aUnion
+          ArrayToVariadicUnion<a, p> extends infer aUnion
             ? {
                 cases: aUnion extends any
                   ? {
@@ -178,6 +170,14 @@ export type FindUnions<
       }>
     >
   : [];
+
+export type ArrayToVariadicUnion<input, excluded> = MaybeAddReadonly<
+  | (input extends readonly [any, ...any] | readonly [...any, any] ? never : [])
+  | (excluded extends readonly [...any, any]
+      ? [...Extract<input, readonly any[]>, ValueOf<input>]
+      : [ValueOf<input>, ...Extract<input, readonly any[]>]),
+  IsReadonlyArray<input>
+>;
 
 // Distribute :: UnionConfig[] -> Union<[a, path][]>
 export type Distribute<unions extends readonly any[]> =


### PR DESCRIPTION
## Performance improvement results

```
tsc --project tests/tsconfig.json --noEmit --extendedDiagnostics
```

| **Category** | **Before** | **After** | **Evolution (%)** |
| --- | --- | --- | --- |
| Files | 206 | 206 | 0% |
| Lines of Library | 40,612 | 40,612 | 0% |
| Lines of Definitions | 27,266 | 27,266 | 0% |
| Lines of TypeScript | 16,129 | 16,149 | 0.12% |
| Lines of JavaScript | 0 | 0 | - |
| Lines of JSON | 0 | 0 | - |
| Lines of Other | 0 | 0 | - |
| Identifiers | 121,119 | 121,150 | 0.03% |
| Symbols | 854,220 | 861,962 | 0.93% |
| Types | 435,316 | 432,599 | -0.65% |
| Instantiations | 6,735,991 | 4,562,378 | -32.33% |
| Memory used | 732,233K | 746,454K | 1.95% |
| Assignability cache size | 209,959 | 205,926 | -1.92% |
| Identity cache size | 28,093 | 28,250 | 0.56% |
| Subtype cache size | 2,944 | 2,944 | 0% |
| Strict subtype cache size | 4,628 | 4,628 | 0% |
| I/O Read time | 0.01s | 0.02s | 100% |
| Parse time | 0.21s | 0.20s | -4.76% |
| ResolveModule time | 0.02s | 0.02s | 0% |
| ResolveTypeReference time | 0.00s | 0.01s | - |
| ResolveLibrary time | 0.01s | 0.01s | 0% |
| Program time | 0.27s | 0.27s | 0% |
| Bind time | 0.13s | 0.13s | 0% |
| Check time | 5.78s | 4.83s | -16.44% |
| printTime time | 0.00s | 0.00s | - |
| Emit time | 0.00s | 0.00s | - |
| Total time | 6.19s | 5.23s | -15.51% |