### PR TITLE
Export Pattern types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,14 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./types": {
+      "require": {
+        "types": "./dist/types/Pattern.d.cts"
+      },
+      "import": {
+        "types": "./dist/types/Pattern.d.ts"
+      }
+    },
     "./package.json": "./package.json"
   },
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     },
     "./types": {
       "require": {
-        "types": "./dist/types/Pattern.d.cts"
+        "types": "./dist/types/index.d.cts"
       },
       "import": {
-        "types": "./dist/types/Pattern.d.ts"
+        "types": "./dist/types/index.d.ts"
       }
     },
     "./package.json": "./package.json"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
       },
       "import": {
         "types": "./dist/types/index.d.ts"
-      }
+      },
+      "types": "./dist/types/index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './Pattern';


### PR DESCRIPTION
Fix issue: https://github.com/gvergnaud/ts-pattern/issues/291

## Changes

Export `Pattern.d.ts` in the package.json to solve the issue. They are now available at `ts-pattern/types`.

## QA

Doing the same changes from this PR in [this playground](https://codesandbox.io/p/devbox/r2jp93?file=%2Fmy-package%2Fexample.ts%3A9%2C21) fixes the TS error