### PR TITLE
Export additional useful types

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,6 @@
+export * from './ExtractPreciseValue';
+export * from './FindSelected';
+export * from './InvertPattern';
+export * from './IsMatching';
+export * from './Match';
 export * from './Pattern';


### PR DESCRIPTION
I'd like access to more internal ts-pattern types to:

- Create wrapper functions around `match` (e.g. from a class method)
- Type generics passed into `match` / `when` / etc.
- Explicitly type matches inside other types, like interfaces
- etc.

I've included exports all of the potential user-facing types I could find – did I miss any?