### PR TITLE
Improvements to `P.infer` and `isMatching`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "prettier": "^2.8.8",
         "rimraf": "^5.0.1",
         "ts-jest": "^29.1.2",
-        "typescript": "^5.3.3"
+        "typescript": "^5.7.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -8230,9 +8230,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -14487,9 +14487,9 @@
       }
     },
     "typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
     "prettier": "^2.8.8",
     "rimraf": "^5.0.1",
     "ts-jest": "^29.1.2",
-    "typescript": "^5.3.3"
+    "typescript": "^5.7.2"
   }
 }

--- a/src/is-matching.ts
+++ b/src/is-matching.ts
@@ -33,10 +33,10 @@ export function isMatching<const p extends Pattern<unknown>>(
  *    return input.name
  *  }
  */
-export function isMatching<const p extends Pattern<unknown>>(
-  pattern: p,
-  value: unknown
-): value is P.infer<p>;
+export function isMatching<const T, const P extends P.Pattern<NoInfer<T>>>(
+  pattern: P,
+  value: T
+): value is P.infer<P>;
 
 export function isMatching<const p extends Pattern<any>>(
   ...args: [pattern: p, value?: any]

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -92,10 +92,7 @@ export type unstable_Matcher<
  * const userPattern = { name: P.string }
  * type User = P.infer<typeof userPattern>
  */
-export type infer<pattern extends Pattern<any>> = InvertPattern<
-  pattern,
-  unknown
->;
+export type infer<pattern> = InvertPattern<NoInfer<pattern>, unknown>;
 
 /**
  * `P.narrow<Input, Pattern>` will narrow the input type to only keep
@@ -110,9 +107,8 @@ export type infer<pattern extends Pattern<any>> = InvertPattern<
  * type Narrowed = P.narrow<Input, typeof Pattern>
  * //     ^? ['a', 'a' | 'b']
  */
-export type narrow<input, pattern extends Pattern<any>> = ExtractPreciseValue<
-  input,
-  InvertPattern<pattern, input>
+export type narrow<input, pattern extends Pattern<any>> = NoInfer<
+  ExtractPreciseValue<input, InvertPattern<pattern, input>>
 >;
 
 function chainable<pattern extends Matcher<any, any, any, any, any>>(

--- a/src/types/FindSelected.ts
+++ b/src/types/FindSelected.ts
@@ -166,4 +166,4 @@ export type FindSelected<i, p> =
   // This happens if the provided pattern didn't extend Pattern<i>,
   // Because the type checker falls back on the general `Pattern<i>` type
   // in this case.
-  Equal<p, Pattern<i>> extends true ? i : Selections<i, p>;
+  NoInfer<Equal<p, Pattern<i>> extends true ? i : Selections<i, p>>;

--- a/src/types/Pattern.ts
+++ b/src/types/Pattern.ts
@@ -145,7 +145,9 @@ export type UnknownPattern =
  * @example
  * const pattern: P.Pattern<User> = { name: P.string }
  */
-export type Pattern<a> = unknown extends a ? UnknownPattern : KnownPattern<a>;
+export type Pattern<a = unknown> = unknown extends a
+  ? UnknownPattern
+  : KnownPattern<a>;
 
 type KnownPattern<a> = KnownPatternInternal<a>;
 

--- a/tests/infer.test.ts
+++ b/tests/infer.test.ts
@@ -22,4 +22,21 @@ describe('P.infer', () => {
       type test2 = Expect<Equal<QuizState, expected2>>;
     });
   });
+
+  it("P.infer shouldn't count as an inference point of the pattern", () => {
+    const getValueOfType = <T extends P.Pattern<unknown>>(
+      obj: unknown,
+      path: string,
+      pattern: T,
+      defaultValue: P.infer<T>
+    ): P.infer<T> => defaultValue;
+
+    getValueOfType(
+      null,
+      'a.b.c',
+      { x: P.string },
+      // @ts-expect-error 👇 error should be here
+      'oops'
+    );
+  });
 });

--- a/tests/is-matching.test.ts
+++ b/tests/is-matching.test.ts
@@ -56,11 +56,11 @@ describe('isMatching', () => {
     }
   });
 
-  it('type inference should be precise without `as const`', () => {
-    type Pizza = { type: 'pizza'; topping: string };
-    type Sandwich = { type: 'sandwich'; condiments: string[] };
-    type Food = Pizza | Sandwich;
+  type Pizza = { type: 'pizza'; topping: string };
+  type Sandwich = { type: 'sandwich'; condiments: string[] };
+  type Food = Pizza | Sandwich;
 
+  it('type inference should be precise without `as const`', () => {
     const food = { type: 'pizza', topping: 'cheese' } as Food;
 
     const isPizza = isMatching({ type: 'pizza' });
@@ -76,5 +76,17 @@ describe('isMatching', () => {
     } else {
       throw new Error('Expected food to match the pizza pattern!');
     }
+  });
+
+  it('should reject invalid pattern when two parameters are passed', () => {
+    const food = { type: 'pizza', topping: 'cheese' } as Food;
+
+    isMatching(
+      {
+        // @ts-expect-error
+        type: 'oops',
+      },
+      food
+    );
   });
 });

--- a/tests/matcher-protocol.test.ts
+++ b/tests/matcher-protocol.test.ts
@@ -26,7 +26,8 @@ describe('matcher protocol', () => {
         match: (input) => {
           return {
             matched:
-              input instanceof Some && isMatching<any>(this.value, input.value),
+              input instanceof Some &&
+              isMatching<any, any>(this.value, input.value),
           };
         },
       };

--- a/tests/not.test.ts
+++ b/tests/not.test.ts
@@ -110,7 +110,9 @@ describe('not', () => {
         .exhaustive()
     ).toBe('hello');
 
-    const untypedNullable = P.when((x) => x === null || x === undefined);
+    const untypedNullable = P.when(
+      (x): boolean => x === null || x === undefined
+    );
 
     expect(
       match<{ str: string }>({ str: 'hello' })


### PR DESCRIPTION
This release contains two changes:

### Typecheck pattern when using isMatching with 2 parameter.

It used to be possible to pass a pattern than could never match to `isMatching`. The new version checks that the provide pattern does match the value in second parameter:

```ts
type Pizza = { type: 'pizza'; topping: string };
type Sandwich = { type: 'sandwich'; condiments: string[] };
type Food = Pizza | Sandwich;

const fn = (food: Pizza | Sandwich) => {
    if (isMatching({ type: 'oops' }, food)) {
        //                  👆 used to type-check, now doesn't!
    }
}

```

### Do not use `P.infer` as an inference point

When using `P.infer<Pattern>` to type a function argument, like in the following example: 

```ts
const getWithDefault = <T extends P.Pattern>(
  input: unknown,
  pattern: T,
  defaultValue: P.infer<T> //  👈
): P.infer<T> =>
  isMatching(pattern, input) ? input : defaultValue
```

TypeScript could get confused and find type errors in the wrong spot:

```ts
const res = getWithDefault(null, { x: P.string }, 'oops') 
//                                     👆           👆 type error should be here
//                                 but it's here 😬
```

This PR fixes this problem
