### PR TITLE
fix(isMatching): Allow unknown properties in pattern

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-pattern",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-pattern",
-      "version": "5.6.0",
+      "version": "5.6.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": " The exhaustive Pattern Matching library for TypeScript.",
   "type": "module",
   "source": "src/index.ts",

--- a/src/is-matching.ts
+++ b/src/is-matching.ts
@@ -1,4 +1,9 @@
-import { MatchedValue, Pattern } from './types/Pattern';
+import {
+  MatchedValue,
+  Pattern,
+  UnknownPattern,
+  UnknownProperties,
+} from './types/Pattern';
 import * as P from './patterns';
 import { matchPattern } from './internals/helpers';
 
@@ -33,10 +38,10 @@ export function isMatching<const p extends Pattern<unknown>>(
  *    return input.name
  *  }
  */
-export function isMatching<const T, const P extends P.Pattern<NoInfer<T>>>(
-  pattern: P,
-  value: T
-): value is P.infer<P>;
+export function isMatching<
+  const T,
+  const P extends P.Pattern<T> & UnknownProperties
+>(pattern: P, value: T): value is P.infer<P>;
 
 export function isMatching<const p extends Pattern<any>>(
   ...args: [pattern: p, value?: any]

--- a/src/types/Pattern.ts
+++ b/src/types/Pattern.ts
@@ -126,11 +126,13 @@ export interface Override<a> {
   [symbols.override]: a;
 }
 
+export type UnknownProperties = { readonly [k: PropertyKey]: unknown };
+
 export type UnknownPattern =
   | readonly []
   | readonly [unknown, ...unknown[]]
   | readonly [...unknown[], unknown]
-  | { readonly [k: string]: unknown }
+  | UnknownProperties
   | Primitives
   | UnknownMatcher;
 

--- a/tests/is-matching.test.ts
+++ b/tests/is-matching.test.ts
@@ -82,11 +82,28 @@ describe('isMatching', () => {
     const food = { type: 'pizza', topping: 'cheese' } as Food;
 
     isMatching(
-      {
-        // @ts-expect-error
-        type: 'oops',
-      },
+      // @ts-expect-error
+      { type: 'oops' },
       food
     );
+  });
+
+  it('should allow patterns targetting one member of a union type', () => {
+    const food = { type: 'pizza', topping: 'cheese' } as Food;
+    expect(isMatching({ topping: 'cheese' }, food)).toBe(true);
+
+    if (isMatching({ topping: 'cheese' }, food)) {
+      type t = Expect<Equal<typeof food, Food & { topping: 'cheese' }>>;
+    }
+  });
+
+  it('should allow targetting unknown properties', () => {
+    const food = { type: 'pizza', topping: 'cheese' } as Food;
+
+    expect(isMatching({ unknownProp: P.instanceOf(Error) }, food)).toBe(false);
+
+    if (isMatching({ unknownProp: P.instanceOf(Error) }, food)) {
+      type t = Expect<Equal<typeof food, Food & { unknownProp: Error }>>;
+    }
   });
 });


### PR DESCRIPTION
The previous release introduced a bug with `isMatching` which made it unable to narrow union types properly, and would make it reject patterns containing extra unknown properties. This PR fixes this


```ts
type Pizza = { type: 'pizza'; topping: string };
type Sandwich = { type: 'sandwich'; condiments: string[] };
type Food = Pizza | Sandwich;

const food = { type: 'pizza', topping: 'cheese' } as Food;

// These patterns used to be reject, but now work:

if (isMatching({ topping: 'cheese' }, food)) {
    // food: Food & { topping: 'cheese' }
}

if (isMatching({ unknownProp: P.instanceOf(Error) }, food)) {
// food: Food & { unknownProp: Error }
}
```
