### PR TITLE
isMatching: improve narrowing

### DIFF
--- a/src/is-matching.ts
+++ b/src/is-matching.ts
@@ -1,6 +1,7 @@
 import { MatchedValue, Pattern, UnknownProperties } from './types/Pattern';
 import * as P from './patterns';
 import { matchPattern } from './internals/helpers';
+import { WithDefault } from './types/helpers';
 
 /**
  * This constraint allows using additional properties
@@ -47,7 +48,7 @@ export function isMatching<const p extends Pattern<unknown>>(
 export function isMatching<const T, const P extends PatternConstraint<T>>(
   pattern: P,
   value: T
-): value is P.infer<P>;
+): value is T & WithDefault<P.narrow<T, P>, P.infer<P>>;
 
 export function isMatching<const p extends Pattern<any>>(
   ...args: [pattern: p, value?: any]

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -127,7 +127,7 @@ export type infer<pattern> = InvertPattern<NoInfer<pattern>, unknown>;
  * type Narrowed = P.narrow<Input, typeof Pattern>
  * //     ^? ['a', 'a' | 'b']
  */
-export type narrow<input, pattern extends Pattern<any>> = ExtractPreciseValue<
+export type narrow<input, pattern> = ExtractPreciseValue<
   input,
   InvertPattern<pattern, input>
 >;

--- a/tests/is-matching.test.ts
+++ b/tests/is-matching.test.ts
@@ -137,7 +137,9 @@ describe('isMatching', () => {
     expect(isMatching({ topping: 'cheese' }, food)).toBe(true);
 
     if (isMatching({ topping: 'cheese' }, food)) {
-      type t = Expect<Equal<typeof food, Food & { topping: 'cheese' }>>;
+      type t = Expect<
+        Equal<typeof food, Pizza & { topping: 'cheese'; type: 'pizza' }>
+      >;
     }
   });
 

--- a/tests/is-matching.test.ts
+++ b/tests/is-matching.test.ts
@@ -152,4 +152,16 @@ describe('isMatching', () => {
       type t = Expect<Equal<typeof food, Food & { unknownProp: Error }>>;
     }
   });
+
+  it('should correctly narrow undiscriminated unions of objects.', () => {
+    type Input = { someProperty: string[] } | { this: 'is a string' };
+    const input = { someProperty: ['hello'] } satisfies Input as Input;
+
+    if (isMatching({ someProperty: P.array() }, input)) {
+      expect(input.someProperty).toEqual(['hello']);
+      type t = Expect<Equal<typeof input.someProperty, string[]>>;
+    } else {
+      throw new Error('pattern should match');
+    }
+  });
 });

--- a/tests/objects.test.ts
+++ b/tests/objects.test.ts
@@ -11,9 +11,8 @@ describe('Objects', () => {
     it('should work with symbols', () => {
       const fn1 = (obj: Input) => {
         if (isMatching({ [symbolA]: { [symbolB]: 'foo' } }, obj)) {
-          type t = Expect<
-            Equal<typeof obj, { [symbolA]: { [symbolB]: 'foo' } }>
-          >;
+          const value = obj[symbolA][symbolB];
+          type t = Expect<Equal<typeof value, 'foo'>>;
         } else {
           throw new Error('Expected obj to match the foo pattern!');
         }
@@ -21,9 +20,8 @@ describe('Objects', () => {
 
       const fn2 = (obj: Input) => {
         if (isMatching({ [symbolA]: { [symbolB]: 'bar' } }, obj)) {
-          type t = Expect<
-            Equal<typeof obj, { [symbolA]: { [symbolB]: 'bar' } }>
-          >;
+          const value = obj[symbolA][symbolB];
+          type t = Expect<Equal<typeof value, 'bar'>>;
           throw new Error('Expected obj to not match the bar pattern!');
         }
       };


### PR DESCRIPTION
`isMatching` didn't have full feature parity with `match` in terms of type narrowing. This PR bridges the gap.