### PR TITLE
chore: re-export InvertPattern

### DIFF
--- a/src/types/Pattern.ts
+++ b/src/types/Pattern.ts
@@ -3,6 +3,8 @@ import { MergeUnion, Primitives, WithDefault } from './helpers';
 import { None, Some, SelectionType } from './FindSelected';
 import { matcher } from '../patterns';
 import { ExtractPreciseValue } from './ExtractPreciseValue';
+// re-export InvertPattern in ts-pattern/types
+export { InvertPattern } from './InvertPattern';
 
 export type MatcherType =
   | 'not'


### PR DESCRIPTION
for `nodenext` moduleResolution strategy, can only access exports defined in package.json. 
Adding this re-export to allow user access `InvertPattern` util types.

```diff
- // not allowed in nodenext moduleResolution
- import { InvertPattern } from "ts-pattern/dist/types/InvertPattern";

+ // use this re-export:
+ import type { InvertPattern } from "ts-pattern/types";
```