### PR TITLE
fix(.exhaustive): optional discriminant

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@gabriel/ts-pattern",
-  "version": "5.6.2",
+  "version": "5.7.1",
   "exports": {
     ".": "./src/index.ts",
     "./types": "./src/index.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-pattern",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-pattern",
-      "version": "5.7.0",
+      "version": "5.7.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-pattern",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "description": " The exhaustive Pattern Matching library for TypeScript.",
   "type": "module",
   "source": "src/index.ts",

--- a/src/types/BuildMany.ts
+++ b/src/types/BuildMany.ts
@@ -1,4 +1,4 @@
-import { Iterator, UpdateAt, ValueOf } from './helpers';
+import { Iterator, IsOptionalKeysOf, UpdateAt, ValueOf } from './helpers';
 
 // BuildMany :: DataStructure -> Union<[value, path][]> -> Union<DataStructure>
 export type BuildMany<data, xs extends readonly any[]> = xs extends any
@@ -31,10 +31,15 @@ export type SetDeep<data, value, path> = path extends readonly [
     : data extends Map<infer k, infer v>
     ? Map<k, SetDeep<v, value, tail>>
     : head extends keyof data
-    ? {
-        [k in keyof data]-?: k extends head
-          ? SetDeep<data[head], value, tail>
-          : data[k];
-      }
+    ? // if we intentionally set undefined on an optional key, we should keep
+      // the optional modifier, otherwise it will exclude the `undefined` type from
+      // our `value` type.
+      [IsOptionalKeysOf<data, head>, tail, undefined] extends [true, [], value]
+      ? { [k in keyof data]: k extends head ? value : data[k] }
+      : {
+          [k in keyof data]-?: k extends head
+            ? SetDeep<data[head], value, tail>
+            : data[k];
+        }
     : data
   : value;

--- a/src/types/InvertPattern.ts
+++ b/src/types/InvertPattern.ts
@@ -363,7 +363,9 @@ type InvertPatternForExcludeInternal<p, i, empty = never> =
         >
       : never
     : IsPlainObject<p> extends true
-    ? i extends object
+    ? Equal<{}, p> extends true
+      ? {}
+      : i extends object
       ? [keyof p & keyof i] extends [never]
         ? empty
         : OptionalKeys<p> extends infer optKeys

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -267,3 +267,10 @@ export interface Fn {
 export type Call<fn extends Fn, input> = (fn & {
   input: input;
 })['output'];
+
+export type IsOptionalKeysOf<obj, key extends keyof obj> = {} extends Pick<
+  obj,
+  key
+>
+  ? true
+  : false;

--- a/tests/deep-exclude.test.ts
+++ b/tests/deep-exclude.test.ts
@@ -128,6 +128,21 @@ describe('DeepExclude', () => {
         >
       ];
     });
+
+    it("should exclude the undefined case of optional properties when the pattern's key is also optional", () => {
+      type input = {
+        type: 'a';
+        data?: { type: 'img'; src: string } | { type: 'text'; p: string };
+      };
+      type pattern = {
+        readonly type: 'a';
+        readonly data?: { readonly type: 'img' };
+      };
+      type res1 = DeepExclude<input, pattern>;
+      type test1 = Expect<
+        Equal<res1, { type: 'a'; data: { type: 'text'; p: string } }>
+      >;
+    });
   });
 
   describe('Tuples', () => {

--- a/tests/optional-props.test.ts
+++ b/tests/optional-props.test.ts
@@ -101,7 +101,7 @@ describe('optional properties', () => {
         return `Foo: ${value.b}`;
       })
       .with({ a: SomeEnum.Bar }, (value) => `Bar: ${value.b}`)
-      .with({ a: undefined }, (value) => `<undefined>: ${value.b}`)
+      .with({ a: P.optional(undefined) }, (value) => `<undefined>: ${value.b}`)
       .exhaustive();
 
     expect(result).toEqual(`Foo: not important`);

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,6 +1,12 @@
 import { Expect, Equal } from '../src/types/helpers';
 import { match, P } from '../src';
 import { State, Event } from './types-catalog/utils';
+import {
+  InvertPattern,
+  InvertPatternForExclude,
+} from '../src/types/InvertPattern';
+import { Chainable, GuardP, NotP } from '../src/types/Pattern';
+import { ExtractPreciseValue } from '../src/types/ExtractPreciseValue';
 
 describe('types', () => {
   type Input = [State, Event];
@@ -151,6 +157,7 @@ describe('types', () => {
       >;
       return 'ok';
     });
+
     match<Input>({ type: 'hello' })
       .with(P.not(P.when((x) => true)), (x) => {
         type t = Expect<Equal<typeof x, Input>>;

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,12 +1,6 @@
 import { Expect, Equal } from '../src/types/helpers';
 import { match, P } from '../src';
 import { State, Event } from './types-catalog/utils';
-import {
-  InvertPattern,
-  InvertPatternForExclude,
-} from '../src/types/InvertPattern';
-import { Chainable, GuardP, NotP } from '../src/types/Pattern';
-import { ExtractPreciseValue } from '../src/types/ExtractPreciseValue';
 
 describe('types', () => {
   type Input = [State, Event];
@@ -157,7 +151,6 @@ describe('types', () => {
       >;
       return 'ok';
     });
-
     match<Input>({ type: 'hello' })
       .with(P.not(P.when((x) => true)), (x) => {
         type t = Expect<Equal<typeof x, Input>>;


### PR DESCRIPTION
This PR fixes #278

This new release fixes the following bug in exhaustiveness checking when matching on optional properties:

```ts
type Input = { type?: 'one' } | { type: 'two' };

const f1 = (input: Input) =>
  match(input)
    .with({ type: 'one' }, () => {})
    .with({ type: 'two' }, () => {})
    .exhaustive(); // shouldn't type-check, but does 👎


const f2 = (input: Input) =>
  match(input)
    .with({ type: 'one' }, () => {})
    .with({ type: 'two' }, () => {})
    .with({ type: undefined }, () => {}) // <- the type key needs to be present.
    .exhaustive();  // shouldn't type-check, but does 👎
```

These two cases don't type check anymore. They fail with a `NonExhaustiveError<{ type?: undefined; }>`. To fix it, you should do:

```ts
type Input = { type?: 'one' } | { type: 'two' };

const f = (input: Input) =>
  match(input)
    .with({ type: 'one' }, () => {})
    .with({ type: 'two' }, () => {})
    .with({ type: P.optional(undefined) }, () => {}) // <- the type property may not be there
    .exhaustive(); // ✅
```

This is a purely type-level change, the runtime behavior is still the same.