### PR TITLE
Fix: Add missing public/index.html to gif-fetcher example

### DIFF
--- a/examples/gif-fetcher/public/index.html
+++ b/examples/gif-fetcher/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>TS-Pattern GIF Search Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>


### PR DESCRIPTION
The gif-fetcher example was missing public/index.html, causing "Could not find a required file" error.

Added the missing file so the example can run.

Fixes #329