### PR TITLE
fix: object patterns no longer match array values

### DIFF
--- a/src/internals/helpers.ts
+++ b/src/internals/helpers.ts
@@ -103,6 +103,12 @@ export const matchPattern = (
         : false;
     }
 
+    // An object pattern must not match an array value, even though arrays are
+    // objects in JavaScript. Without this guard an empty pattern `{}` would
+    // vacuously match any array because `Reflect.ownKeys({}).every(…)` is true
+    // for an empty iterable. See https://github.com/gvergnaud/ts-pattern/issues/309
+    if (Array.isArray(value)) return false;
+
     return Reflect.ownKeys(pattern).every((k): boolean => {
       const subPattern = pattern[k];
 

--- a/tests/objects.test.ts
+++ b/tests/objects.test.ts
@@ -125,4 +125,39 @@ describe('Records ({})', () => {
         .otherwise(() => 'no match')
     ).toEqual('vector1');
   });
+
+  it('issue #309: arrays should not match object patterns', () => {
+    // An empty array is an object in JavaScript, so {} would vacuously match it.
+    // The fix ensures that a non-array pattern never matches an array value.
+    expect(
+      match<any, string>([])
+        .with({}, () => 'matched object pattern')
+        .otherwise(() => 'no match')
+    ).toEqual('no match');
+
+    expect(
+      match<any, string>([1, 2, 3])
+        .with({}, () => 'matched object pattern')
+        .otherwise(() => 'no match')
+    ).toEqual('no match');
+
+    expect(
+      match<any, string>([1, 2, 3])
+        .with({ length: 3 }, () => 'matched object pattern')
+        .otherwise(() => 'no match')
+    ).toEqual('no match');
+
+    // Plain objects should still match object patterns
+    expect(
+      match<any, string>({})
+        .with({}, () => 'matched')
+        .otherwise(() => 'no match')
+    ).toEqual('matched');
+
+    expect(
+      match<any, string>({ a: 1 })
+        .with({ a: 1 }, () => 'matched')
+        .otherwise(() => 'no match')
+    ).toEqual('matched');
+  });
 });


### PR DESCRIPTION
## Problem

Arrays are objects in JavaScript, which means `typeof [] === 'object'`. Because of this, when matching an array value against an object pattern like `{}`, the runtime matcher entered the object-pattern branch and called `Reflect.ownKeys({}).every(…)`. Since `every` on an empty iterable always returns `true`, **any array — including `[]` — matched the empty object pattern `{}`**.

```ts
match([]).with({}, () => 'matched').otherwise(() => 'not matched')
// Expected: 'not matched'
// Actual:   'matched'  ← bug
```

Reported in #309.

## Root cause

In `src/internals/helpers.ts`, `matchPattern` checks `isObject(pattern)` first, which is true for plain objects. Inside that block it checks `Array.isArray(pattern)` to handle tuple patterns, but it did **not** check whether `value` is an array before falling through to the plain-object key iteration:

```ts
// Before fix — no guard against array values here:
return Reflect.ownKeys(pattern).every((k) => …);
```

## Fix

Add a single `Array.isArray(value)` guard immediately before the `Reflect.ownKeys` iteration so that a non-array pattern is rejected when the value happens to be an array:

```ts
// After fix:
if (Array.isArray(value)) return false;
return Reflect.ownKeys(pattern).every((k) => …);
```

## Test evidence

New test in `tests/objects.test.ts` under `issue #309`:

| case | before fix | after fix |
|---|---|---|
| `match<any>([]).with({}, …)` | `'matched object pattern'` | `'no match'` |
| `match<any>([1,2,3]).with({}, …)` | `'matched object pattern'` | `'no match'` |
| `match<any>([1,2,3]).with({ length: 3 }, …)` | `'matched object pattern'` | `'no match'` |
| `match<any>({}).with({}, …)` | `'matched'` (correct) | `'matched'` (still correct) |
| `match<any>({ a:1 }).with({ a:1 }, …)` | `'matched'` (correct) | `'matched'` (still correct) |

Full suite: **454/454 tests pass** after the fix.

Closes #309