### PR TITLE
Fix nullable NoInfer handler narrowing

### DIFF
--- a/src/types/Pattern.ts
+++ b/src/types/Pattern.ts
@@ -1,5 +1,12 @@
 import type * as symbols from '../internals/symbols';
-import { MergeUnion, Primitives, WithDefault } from './helpers';
+import {
+  Contains,
+  IsAny,
+  IsNever,
+  MergeUnion,
+  Primitives,
+  WithDefault,
+} from './helpers';
 import { None, Some, SelectionType } from './FindSelected';
 import { matcher } from '../patterns';
 import { ExtractPreciseValue } from './ExtractPreciseValue';
@@ -73,7 +80,17 @@ type PatternMatcher<input> = Matcher<input, unknown, any, any>;
 // We fall back to `a` if we weren't able to extract anything more precise
 export type MatchedValue<a, invpattern> = WithDefault<
   ExtractPreciseValue<a, invpattern>,
-  a
+  IsNever<invpattern> extends true
+    ? a
+    : IsAny<invpattern> extends true
+    ? a
+    : unknown extends invpattern
+    ? a
+    : invpattern extends object
+    ? Contains<invpattern, never> extends true
+      ? a
+      : a & invpattern
+    : a
 >;
 
 export type AnyMatcher = Matcher<any, any, any, any, any>;

--- a/tests/wildcards.test.ts
+++ b/tests/wildcards.test.ts
@@ -114,6 +114,33 @@ describe('wildcards', () => {
       );
     });
 
+    it('should narrow nullable NoInfer object properties correctly', () => {
+      type User = { name: string | null };
+
+      const withNoInfer = (value: NoInfer<User | null> | null) =>
+        match(value)
+          .with({ name: P.nonNullable }, ({ name }) => {
+            type t = Expect<Equal<typeof name, string>>;
+            return `Hello ${name}`;
+          })
+          .otherwise(() => null);
+
+      const withoutNoInfer = (value: User | null) =>
+        match(value)
+          .with({ name: P.nonNullable }, ({ name }) => {
+            type t = Expect<Equal<typeof name, string>>;
+            return `Hello ${name}`;
+          })
+          .otherwise(() => null);
+
+      expect(withNoInfer({ name: 'Gabriel' })).toBe('Hello Gabriel');
+      expect(withNoInfer({ name: null })).toBeNull();
+      expect(withNoInfer(null)).toBeNull();
+      expect(withoutNoInfer({ name: 'Gabriel' })).toBe('Hello Gabriel');
+      expect(withoutNoInfer({ name: null })).toBeNull();
+      expect(withoutNoInfer(null)).toBeNull();
+    });
+
     it('combined with exhaustive, it should consider all values except null and undefined to be handled', () => {
       const fn1 = (input: string | number | null | undefined) =>
         match(input)


### PR DESCRIPTION
## Summary
- Add a regression test for nullable `NoInfer<User | null> | null` values with `P.nonNullable` property patterns.
- Preserve useful handler narrowing when precise extraction falls back by intersecting safe inverted object patterns with the input type.
- Keep fallback behavior unchanged for `never`, `any`, `unknown`, primitive, and impossible object patterns.

## Verification
- `npm run check -- --noErrorTruncation`
- `npm test`

## Performance benchmarks
Measured with `tsc --project tests/tsconfig.json --noEmit --extendedDiagnostics` (TypeScript 5.9.2), interleaved A/B runs with warmup:

**Fix alone (identical test corpus, 8 runs):**

| Metric | `main` | fix | delta |
|---|---|---|---|
| Check time | 9.11s | 9.12s | **+0.2%** (noise) |
| Types | 498,747 | 498,747 | identical |
| Instantiations | 3,887,447 | 3,887,447 | identical |

**Fix + new NoInfer test vs plain `main` (6 runs):**

| Metric | `main` | fix + test | delta |
|---|---|---|---|
| Check time | 9.11s | 9.11s | none |
| Types | 498,747 | 499,498 | +0.15% |
| Instantiations | 3,887,447 | 3,892,391 | +0.38% |

The fix only adds a fallback branch inside `MatchedValue`'s `WithDefault`, so when `ExtractPreciseValue` succeeds (the normal case) the cost is zero — confirmed by identical type/instantiation counts. The tiny increase in the second scenario comes from the new test itself (two extra `match` expressions).

Closes #354
<!-- This is an auto-generated description by cubic. -->

---

## Summary by cubic
Fixes handler narrowing for nullable `NoInfer` objects when matching with `P.nonNullable`, so properties like `name` narrow to `string` as expected. Updates the `MatchedValue` fallback to preserve useful narrowing without changing behavior for `never`, `any`, `unknown`, primitives, or impossible patterns. Closes #354.

- **Bug Fixes**
  - Added a regression test for `NoInfer<User | null> | null` with `{ name: P.nonNullable }`.
  - Adjusted `MatchedValue` to intersect `a & invpattern` only for safe object patterns.

<sup>Written for commit e0274cf54cf70a38b130469772cfcdecc0cb0316. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gvergnaud/ts-pattern/pull/355?utm_source=github" target="_blank" rel="noopener noreferrer" data-new-issue-icon="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-light.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
