### PR TITLE
fix(build): override rollup-plugin-typescript2 for picomatch compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8127,16 +8127,16 @@
       }
     },
     "node_modules/rollup-plugin-typescript2": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.32.1.tgz",
-      "integrity": "sha512-RanO8bp1WbeMv0bVlgcbsFNCn+Y3rX7wF97SQLDxf0fMLsg0B/QFF005t4AsGUcDgF3aKJHoqt4JF2xVaABeKw==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.37.0.tgz",
+      "integrity": "sha512-S1r/4Ufi13Yg/chPlh4iSHWq2Zs/sIAodW5SKUoCQfy/DEQhkS2XRFEtv+NRq3iBO4WHHfqKtDPOC5lJTYm7OQ==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^4.1.2",
         "find-cache-dir": "^3.3.2",
         "fs-extra": "^10.0.0",
-        "resolve": "^1.20.0",
-        "tslib": "^2.4.0"
+        "semver": "^7.5.4",
+        "tslib": "^2.6.2"
       },
       "peerDependencies": {
         "rollup": ">=1.26.3",
@@ -8154,6 +8154,18 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/rollup-plugin-typescript2/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/rollup-plugin-visualizer": {
@@ -8772,9 +8784,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true
     },
     "node_modules/type-detect": {
@@ -13818,7 +13830,7 @@
         "rollup-plugin-bundle-size": "^1.0.3",
         "rollup-plugin-postcss": "^4.0.0",
         "rollup-plugin-terser": "^7.0.2",
-        "rollup-plugin-typescript2": "^0.32.0",
+        "rollup-plugin-typescript2": "0.37.0",
         "rollup-plugin-visualizer": "^5.6.0",
         "sade": "^1.7.4",
         "terser": "^5.7.0",
@@ -14839,16 +14851,16 @@
       }
     },
     "rollup-plugin-typescript2": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.32.1.tgz",
-      "integrity": "sha512-RanO8bp1WbeMv0bVlgcbsFNCn+Y3rX7wF97SQLDxf0fMLsg0B/QFF005t4AsGUcDgF3aKJHoqt4JF2xVaABeKw==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.37.0.tgz",
+      "integrity": "sha512-S1r/4Ufi13Yg/chPlh4iSHWq2Zs/sIAodW5SKUoCQfy/DEQhkS2XRFEtv+NRq3iBO4WHHfqKtDPOC5lJTYm7OQ==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^4.1.2",
         "find-cache-dir": "^3.3.2",
         "fs-extra": "^10.0.0",
-        "resolve": "^1.20.0",
-        "tslib": "^2.4.0"
+        "semver": "^7.5.4",
+        "tslib": "^2.6.2"
       },
       "dependencies": {
         "@rollup/pluginutils": {
@@ -14860,6 +14872,12 @@
             "estree-walker": "^2.0.1",
             "picomatch": "^2.2.2"
           }
+        },
+        "semver": {
+          "version": "7.8.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+          "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+          "dev": true
         }
       }
     },
@@ -15300,9 +15318,9 @@
       }
     },
     "tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true
     },
     "type-detect": {

--- a/package.json
+++ b/package.json
@@ -79,5 +79,11 @@
     "rimraf": "^5.0.1",
     "ts-jest": "^29.4.1",
     "typescript": "^5.9.2"
+  },
+  "overrides": {
+    "microbundle": {
+      ".": "$microbundle",
+      "rollup-plugin-typescript2": "0.37.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Override Microbundle's `rollup-plugin-typescript2` dependency to version `0.37.0`.

This restores the build on the current `main` branch after the upgrade to `picomatch@2.3.2`.

## Root cause

`microbundle@0.15.1` uses an older version of `rollup-plugin-typescript2`.

That version uses the following default include patterns for TypeScript files:

```text
*.ts+(|x)
**/*.ts+(|x)
```

After the upgrade to `picomatch@2.3.2`, these patterns no longer match plain `.ts` files.

As a result:

1. `rollup-plugin-typescript2` skips plain `.ts` source files.
2. TypeScript syntax is not transformed into JavaScript.
3. The untransformed source reaches Babel.
4. Babel fails while parsing statements such as `export type`.

`rollup-plugin-typescript2@0.37.0` uses the compatible patterns:

```text
*.ts{,x}
**/*.ts{,x}
```

## Changes

Added a scoped npm override so that only Microbundle's `rollup-plugin-typescript2` dependency is replaced:

```json
"overrides": {
  "microbundle": {
    ".": "$microbundle",
    "rollup-plugin-typescript2": "0.37.0"
  }
}
```

The Microbundle version itself remains unchanged.

## Bisect result

`git bisect` identified the first bad commit as:

```text
8d4b56c8fb4f04e0a33be7679a9f8b15e9e2dcfe
build(deps): bump picomatch
```

The parent commit builds successfully in the same environment.

## Verification

Verified from a clean installation:

```bash
rm -rf node_modules dist
npm ci
npm run build
```

Additional checks:

- `npm run check`
- `npm test` — 48 test suites and 453 tests passed
- `git diff --check`

The build successfully generated the expected CJS, ESM, and UMD bundles.

Fixes #360 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the build after upgrading to `picomatch@2.3.2` by overriding `microbundle`’s `rollup-plugin-typescript2` to `0.37.0`, ensuring `.ts` files are correctly matched and transpiled.

- **Bug Fixes**
  - Root cause: `microbundle@0.15.1` depended on `rollup-plugin-typescript2@0.32.x` which used `*.ts+(|x)` patterns that no longer match in `picomatch@2.3.2`, so `.ts` files were skipped and Babel failed.
  - Fix: Added an npm `overrides` block to pin only `microbundle`’s `rollup-plugin-typescript2` to `0.37.0` (uses `*.ts{,x}`); `microbundle` itself is unchanged.
  - Result: Build succeeds and outputs CJS/ESM/UMD bundles; tests pass.

<sup>Written for commit 9ff13372168990571f8dcf9cd88b0e8d2e19ff04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/gvergnaud/ts-pattern/pull/361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

